### PR TITLE
feat(context): editable context playground with token counting

### DIFF
--- a/src/components/Modals.js
+++ b/src/components/Modals.js
@@ -234,7 +234,8 @@ export function Modals({ toggleModal, currentThemeName, setCurrentThemeName, all
 			handleMemoryTokensChange=${handleMemoryTokensChange}
 			finalPromptText=${useChatAPI ? JSON.stringify(convertChatToJSON(finalPromptText, templates[selectedTemplate]), null, 4) : finalPromptText}
 			defaultPresets=${defaultPresets}
-			cancel=${cancel}/>
+			cancel=${cancel}
+			apiConfig=${{ sessionStorage, endpoint, endpointAPI, endpointAPIKey, isMiyapadEndpoint, useServerTokenization }}/>
 
 		<${WorldInfoModal}
 			isOpen=${modalState.wi}

--- a/src/components/modals/ContextModal.js
+++ b/src/components/modals/ContextModal.js
@@ -1,8 +1,58 @@
 import { html } from 'htm/react';
+import { useState, useEffect, useRef } from 'react';
 import { Modal } from '../Modal.js';
 import { CollapsibleGroup } from '../controls/CollapsibleGroup.js';
+import { getTokenCount, serverTokenCount } from '../../api/index.js';
+import { API_OPENAI_COMPAT, API_LLAMA_CPP } from '../../constants.js';
 
-export function ContextModal({ isOpen, closeModal, tokens, memoryTokens, authorNoteTokens, handleMemoryTokensChange, finalPromptText, defaultPresets, cancel }) {
+export function ContextModal({ isOpen, closeModal, tokens, memoryTokens, authorNoteTokens, handleMemoryTokensChange, finalPromptText, defaultPresets, cancel, apiConfig }) {
+	const { sessionStorage, endpoint, endpointAPI, endpointAPIKey, isMiyapadEndpoint, useServerTokenization } = apiConfig;
+	const [contextPlayground, setContextPlayground] = useState(finalPromptText);
+	const [playgroundTokens, setPlaygroundTokens] = useState(tokens);
+	const playgroundRef = useRef(contextPlayground);
+	useEffect(() => {
+		playgroundRef.current = contextPlayground;
+	}, [contextPlayground]);
+	useEffect(() => {
+		if (isOpen) setContextPlayground(finalPromptText);
+	}, [isOpen, finalPromptText]);
+	useEffect(() => {
+		if (isOpen) setPlaygroundTokens(tokens);
+	}, [isOpen, tokens]);
+	useEffect(() => {
+		if (endpointAPI == API_OPENAI_COMPAT)
+			return;
+		const canServerTokenize = useServerTokenization && isMiyapadEndpoint && sessionStorage?.sessionEndpoint;
+		let cancelled = false;
+		const to = setTimeout(async () => {
+			const content = playgroundRef.current;
+			try {
+				const count = await getTokenCount({
+					endpoint,
+					endpointAPI,
+					...(endpointAPI == API_OPENAI_COMPAT || endpointAPI == API_LLAMA_CPP ? { endpointAPIKey } : {}),
+					content,
+					...(isMiyapadEndpoint ? { proxyEndpoint: sessionStorage.proxyEndpoint } : {})
+				});
+				if (!cancelled) setPlaygroundTokens(count);
+			} catch (e) {
+				if (!cancelled) {
+					if (canServerTokenize) {
+						try {
+							const count = await serverTokenCount({ sessionEndpoint: sessionStorage.sessionEndpoint, content });
+							if (!cancelled) setPlaygroundTokens(count);
+							return;
+						} catch (e2) {
+							if (!cancelled)
+								reportError(e2);
+						}
+					}
+					reportError(e);
+				}
+			}
+		}, 500);
+		return () => { cancelled = true; clearTimeout(to); };
+	}, [contextPlayground]);
 	return html`
 		<${Modal} isOpen=${isOpen} onClose=${closeModal}
 			title="Context"
@@ -26,9 +76,9 @@ export function ContextModal({ isOpen, closeModal, tokens, memoryTokens, authorN
 						<td>${memoryTokens.tokens}</td>
 						<td>${memoryTokens.tokensWI}</td>
 						<td>${authorNoteTokens.tokens}</td>
-						<td>${tokens - authorNoteTokens.tokens - memoryTokens.tokensWI - memoryTokens.tokens}</td>
+						<td>${Math.max(0, playgroundTokens - memoryTokens.tokens - memoryTokens.tokensWI - authorNoteTokens.tokens)}</td>
 						<td></td>
-						<td>${tokens}</td>
+						<td>${playgroundTokens}</td>
 					</tr>
 				</tbody>
 			</table>
@@ -80,9 +130,14 @@ export function ContextModal({ isOpen, closeModal, tokens, memoryTokens, authorN
 					id="advanced-context-order-settings"/>
 			</${CollapsibleGroup}>
 			<textarea
-				readOnly
-				value=${finalPromptText}
+				value=${contextPlayground}
+				onInput=${(e) => setContextPlayground(e.target.value)}
 				class="expanded-text-area-settings"
 				id="context-area-settings" />
+			<div class="hbox" style=${{ justifyContent: 'flex-end', marginTop: '8px' }}>
+				<button onClick=${() => setContextPlayground(finalPromptText)}>
+					Reset Context
+				</button>
+			</div>
 		</${Modal}>`;
 }

--- a/src/components/modals/ContextModal.js
+++ b/src/components/modals/ContextModal.js
@@ -20,39 +20,30 @@ export function ContextModal({ isOpen, closeModal, tokens, memoryTokens, authorN
 		if (isOpen) setPlaygroundTokens(tokens);
 	}, [isOpen, tokens]);
 	useEffect(() => {
-		if (endpointAPI == API_OPENAI_COMPAT)
-			return;
-		const canServerTokenize = useServerTokenization && isMiyapadEndpoint && sessionStorage?.sessionEndpoint;
-		let cancelled = false;
+		const ac = new AbortController();
 		const to = setTimeout(async () => {
 			const content = playgroundRef.current;
 			try {
-				const count = await getTokenCount({
-					endpoint,
-					endpointAPI,
-					...(endpointAPI == API_OPENAI_COMPAT || endpointAPI == API_LLAMA_CPP ? { endpointAPIKey } : {}),
-					content,
-					...(isMiyapadEndpoint ? { proxyEndpoint: sessionStorage.proxyEndpoint } : {})
-				});
-				if (!cancelled) setPlaygroundTokens(count);
+				const count = await (useServerTokenization && isMiyapadEndpoint && sessionStorage?.sessionEndpoint
+					? serverTokenCount({ sessionEndpoint: sessionStorage.sessionEndpoint, content, signal: ac.signal })
+					: getTokenCount({
+						endpoint,
+						endpointAPI,
+						...(endpointAPI == API_OPENAI_COMPAT || endpointAPI == API_LLAMA_CPP ? { endpointAPIKey } : {}),
+						content,
+						signal: ac.signal,
+						...(isMiyapadEndpoint ? { proxyEndpoint: sessionStorage.proxyEndpoint } : {})
+					})
+				);
+				setPlaygroundTokens(count);
 			} catch (e) {
-				if (!cancelled) {
-					if (canServerTokenize) {
-						try {
-							const count = await serverTokenCount({ sessionEndpoint: sessionStorage.sessionEndpoint, content });
-							if (!cancelled) setPlaygroundTokens(count);
-							return;
-						} catch (e2) {
-							if (!cancelled)
-								reportError(e2);
-						}
-					}
+				if (e.name !== 'AbortError')
 					reportError(e);
-				}
 			}
 		}, 500);
-		return () => { cancelled = true; clearTimeout(to); };
-	}, [contextPlayground]);
+		ac.signal.addEventListener('abort', () => clearTimeout(to));
+		return () => ac.abort();
+	}, [contextPlayground, endpoint, endpointAPI, useServerTokenization]);
 	return html`
 		<${Modal} isOpen=${isOpen} onClose=${closeModal}
 			title="Context"

--- a/src/components/modals/ContextModal.js
+++ b/src/components/modals/ContextModal.js
@@ -38,8 +38,10 @@ export function ContextModal({ isOpen, closeModal, tokens, memoryTokens, authorN
 				);
 				setPlaygroundTokens(count);
 			} catch (e) {
-				if (e.name !== 'AbortError')
+				if (e.name !== 'AbortError') {
 					reportError(e);
+					setPlaygroundTokens(0);
+				}
 			}
 		}, 500);
 		ac.signal.addEventListener('abort', () => clearTimeout(to));

--- a/src/components/modals/ContextModal.js
+++ b/src/components/modals/ContextModal.js
@@ -20,6 +20,7 @@ export function ContextModal({ isOpen, closeModal, tokens, memoryTokens, authorN
 		if (isOpen) setPlaygroundTokens(tokens);
 	}, [isOpen, tokens]);
 	useEffect(() => {
+		if (!isOpen) return;
 		const ac = new AbortController();
 		const to = setTimeout(async () => {
 			const content = playgroundRef.current;
@@ -43,7 +44,7 @@ export function ContextModal({ isOpen, closeModal, tokens, memoryTokens, authorN
 		}, 500);
 		ac.signal.addEventListener('abort', () => clearTimeout(to));
 		return () => ac.abort();
-	}, [contextPlayground, endpoint, endpointAPI, useServerTokenization]);
+	}, [isOpen, contextPlayground, endpoint, endpointAPI, useServerTokenization]);
 	return html`
 		<${Modal} isOpen=${isOpen} onClose=${closeModal}
 			title="Context"

--- a/src/components/modals/ContextModal.js
+++ b/src/components/modals/ContextModal.js
@@ -1,5 +1,5 @@
 import { html } from 'htm/react';
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useRef } from 'react';
 import { Modal } from '../Modal.js';
 import { CollapsibleGroup } from '../controls/CollapsibleGroup.js';
 import { getTokenCount, serverTokenCount } from '../../api/index.js';
@@ -9,12 +9,14 @@ export function ContextModal({ isOpen, closeModal, tokens, memoryTokens, authorN
 	const { sessionStorage, endpoint, endpointAPI, endpointAPIKey, isMiyapadEndpoint, useServerTokenization } = apiConfig;
 	const [contextPlayground, setContextPlayground] = useState(finalPromptText);
 	const [playgroundTokens, setPlaygroundTokens] = useState(tokens);
+	const prevIsOpen = useRef(isOpen);
 	useEffect(() => {
-		if (isOpen) setContextPlayground(finalPromptText);
-	}, [isOpen, finalPromptText]);
-	useEffect(() => {
-		if (isOpen) setPlaygroundTokens(tokens);
-	}, [isOpen, tokens]);
+		if (isOpen && !prevIsOpen.current) {
+			setContextPlayground(finalPromptText);
+			setPlaygroundTokens(tokens);
+		}
+		prevIsOpen.current = isOpen;
+	}, [isOpen, finalPromptText, tokens]);
 	useEffect(() => {
 		if (!isOpen) return;
 		const ac = new AbortController();

--- a/src/components/modals/ContextModal.js
+++ b/src/components/modals/ContextModal.js
@@ -1,5 +1,5 @@
 import { html } from 'htm/react';
-import { useState, useEffect, useRef } from 'react';
+import { useState, useEffect } from 'react';
 import { Modal } from '../Modal.js';
 import { CollapsibleGroup } from '../controls/CollapsibleGroup.js';
 import { getTokenCount, serverTokenCount } from '../../api/index.js';
@@ -9,10 +9,6 @@ export function ContextModal({ isOpen, closeModal, tokens, memoryTokens, authorN
 	const { sessionStorage, endpoint, endpointAPI, endpointAPIKey, isMiyapadEndpoint, useServerTokenization } = apiConfig;
 	const [contextPlayground, setContextPlayground] = useState(finalPromptText);
 	const [playgroundTokens, setPlaygroundTokens] = useState(tokens);
-	const playgroundRef = useRef(contextPlayground);
-	useEffect(() => {
-		playgroundRef.current = contextPlayground;
-	}, [contextPlayground]);
 	useEffect(() => {
 		if (isOpen) setContextPlayground(finalPromptText);
 	}, [isOpen, finalPromptText]);
@@ -23,7 +19,7 @@ export function ContextModal({ isOpen, closeModal, tokens, memoryTokens, authorN
 		if (!isOpen) return;
 		const ac = new AbortController();
 		const to = setTimeout(async () => {
-			const content = playgroundRef.current;
+			const content = contextPlayground;
 			try {
 				const count = await (useServerTokenization && isMiyapadEndpoint && sessionStorage?.sessionEndpoint
 					? serverTokenCount({ sessionEndpoint: sessionStorage.sessionEndpoint, content, signal: ac.signal })

--- a/src/css/_base.css
+++ b/src/css/_base.css
@@ -106,10 +106,10 @@ body {
 }
 
 .expanded-text-area-settings {
-	margin: 8px 0 8px 0;
+	margin: 8px 0 0 0;
 	width:100%;
 	box-sizing: border-box;
-	height:25.5em;
+	height:24em;
 }
 
 #markdown-preview {


### PR DESCRIPTION
Makes #context-area-settings editable as a context playground. Resets to current context on modal open. Includes a Reset Context button and live token counting via getTokenCount with serverTokenCount fallback.