### PR TITLE
feat: add Connection Manager with per-session connection presets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,9 +31,6 @@ desktop.ini
 *.swp
 *.swo
 
-# Scratch / debug scripts
-server/scratch_list_tables.js
-
 # Personal TODO lists
 session-todo.md
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,16 @@
 
 ## [???] - unreleased
 
+### Added
+- Connection Manager: save and switch between connection presets (endpoint, API type, model, API key) per session
+- New modal for managing connection presets with model browser and API-specific settings
+
 ### Fixed
+- Modal overlay now requires mousedown on the backdrop before click-to-close, preventing accidental dismissal when dragging text
 - Modal tooltips no longer clipped by `.modal-content overflow: hidden` — changed to `overflow: visible` so absolutely-positioned tooltips can appear above input fields
+
+### Changed
+- Session exports no longer include `endpoint` and `endpointAPIKey` fields (credential stripping)
 
 ## [2.3.2] - 2026-06-09
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### Fixed
 - Modal overlay now requires mousedown on the backdrop before click-to-close, preventing accidental dismissal when dragging text
-- Modal tooltips no longer clipped by `.modal-content overflow: hidden` — changed to `overflow: visible` so absolutely-positioned tooltips can appear above input fields
+- Modal tooltips no longer clipped by the modal content area — they now appear above input fields as intended
 
 ### Changed
 - Session exports no longer include `endpoint` and `endpointAPIKey` fields (credential stripping)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,24 +3,29 @@
 ## [???] - unreleased
 
 ### Added
+
 - Connection Manager: save and switch between connection presets (endpoint, API type, model, API key) per session
 - New modal for managing connection presets with model browser and API-specific settings
 
 ### Fixed
+
 - Modal overlay now requires mousedown on the backdrop before click-to-close, preventing accidental dismissal when dragging text
 - Modal tooltips no longer clipped by the modal content area — they now appear above input fields as intended
 
 ### Changed
+
 - Session exports no longer include `endpoint` and `endpointAPIKey` fields (credential stripping)
 
 ## [2.3.2] - 2026-06-09
 
 ### Fixed
+
 - Hardcoded 5-minute `zstd_incremental_maintenance` loop no longer runs unconditionally; the user-configured scheduler (mode, interval) now fully controls periodic maintenance. Default mode `shutdown` means zero automatic maintenance until server stop.
 
 ## [2.3.1] - 2026-06-09
 
 ### Changed
+
 - Replaced `PRAGMA incremental_vacuum` with `zstd_incremental_maintenance` scheduler; added configurable maintenance mode (interval/startup/shutdown), duration, DB load, and optional WAL journal mode
 - Renamed endpoints: `POST /incremental_vacuum` → `/zstd_maintenance`, `GET/POST /vacuum_config` → `/maintenance_config`
 - Second SIGINT during maintenance shutdown now gracefully ignored
@@ -32,12 +37,15 @@
 ## [2.3.0] - 2026-06-09
 
 ### Removed
+
 - Unused `hideChatTemplates` feature (behind-the-scenes prompt affix-stripping mode that had no UI toggle)
 
 ### Changed
+
 - Automatic backups are now gzip-compressed (`.backup.gz` instead of `.backup`); can be opened with any archive tool (7-Zip, Ark, etc.)
 
 ### Added
+
 - DeepSeek provider — dedicated API support using `https://api.deepseek.com` with chat completions (`/chat/completions`) and FIM completions (`/beta/completions`); sidebar integration with API selector, read-only server input, and forced chat mode; skips token counting; EBNF grammar help
 - Quick Switcher overlay (`Ctrl+P` / `Cmd+P`) to search and switch sessions via keyboard
 - Pin/star sessions — click the star icon in the sessions modal to pin a session so it always floats to the top of the list; star indicator also shown in the Quick Switcher
@@ -45,6 +53,7 @@
 - Session tags — freeform tags on sessions with inline editing, AND/OR/NOT/wildcard tag filtering, and tooltip help in the Sessions modal
 
 ### Fixed
+
 - Sidebar endpoint API switch no longer preserves pathname from the previous endpoint URL
 - Session switch no longer updates the last modified date
 - DeepSeek completions 400 error — `logprobs` now sent as integer (per API spec) instead of boolean for FIM endpoint
@@ -54,18 +63,22 @@
 ## [2.2.0] - 2026-06-06
 
 ### Added
+
 - Editable context playground with live token counting in ContextModal
 
 ### Fixed
+
 - ReDoS vulnerability in logit bias token ID regex
 - Context playground state syncing only on modal open (not on every prop change)
 - Token count reset to 0 on error for consistency
 - Unnecessary API calls by guarding token counting effect with `isOpen`
 
 ### Changed
+
 - Rename AGENTS.md section header from "Quick Links" to "Documentation"
 
 ### Performance
+
 - Optimize `onInput` for long prompts: O(n²) back-matching → O(n) via push+reverse
 - Add early-exit for append/deletion in cleanToOrig block using startsWith/endsWith
 - Replace string concatenation with array join in affix reconstruction
@@ -73,17 +86,20 @@
 ## [2.1.0] - 2026-05-31
 
 ### Added
+
 - Fade out animation on modal close (by @LordFoogThe4rd)
 - UI animations and transitions (by @bg-l2norm)
 - Tab content fade-in animation for PreferencesModal
 
 ### Fixed
+
 - SQL injection in zstd_incremental_maintenance endpoint
 - Path traversal in proxy endpoints and tokenizer loader
 - Incomplete URL sanitization in openai.js and koboldcpp.js
 - SSRF protection and XSS reflection in error responses
 
 ### Changed
+
 - Replace sort arrow swap with CSS rotate for smoother transitions
 - Add .gitattributes for automatic LF line endings
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,11 @@
 
 - Modal overlay now requires mousedown on the backdrop before click-to-close, preventing accidental dismissal when dragging text
 - Modal tooltips no longer clipped by the modal content area — they now appear above input fields as intended
+- Connection settings for strict mode and chat API toggle now apply to DeepSeek connections, not just OpenAI Compatible
+- Connection clone now performs a deep copy to prevent shared references between original and duplicate
+- Default endpoint for new connections changed from HTTPS to HTTP to avoid TLS certificate errors on local servers
+- Rapidly clicking "Refresh List" in the connection model browser no longer risks stale data overwriting newer results
+- Storage errors during connection save no longer leave the database and memory in an inconsistent state
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ Miyapad is a user-friendly, browser-based interface for interacting with languag
 ## Features
 
 * **Multiple Backends**: Supports **llama.cpp**, **koboldcpp**, **AI Horde**, and any **OpenAI Compatible** API.
+* **Connection Manager**: Save named connection presets (endpoint, API type, API key, model) and switch between them per-session. Each session remembers its selected connection. Presets include per-API-type settings, a model browser, and CRUD operations (create, clone, delete, enable/disable).
 * **Session Persistence**: Your prompt is automatically saved and restored across multiple sessions. Import and export sessions for sharing or backups. The dedicated Sessions modal provides search, sort by name/created/modified, and a table layout for managing sessions. Database schema v4 with per-table column names avoids compression index collisions, with automatic V2→V3→V4 migration.
 * **Optional Server**: Can be hosted on a local Node.js server for remote or LAN access. Features a modular architecture (`routes/` and `lib/` instead of monolithic `server.js`), **sqlite-zstd** transparent Zstandard compression with auto-vacuum and background dictionary training, and optional **server-side tokenization** — drop a `tokenizer.json` into `server/tokenizers/<name>/` and enable via Preferences → Server.
 * **Persistent Context**:
@@ -27,7 +28,7 @@ Miyapad is a user-friendly, browser-based interface for interacting with languag
 
 ### Architecture
 
-This refactored fork moves from a single monolithic HTML file to a **modular Parcel 2 project** (~60+ files across `src/`). The monolithic `styles.css` is split into 18 component-specific partials under `src/css/`, and global state is managed via **React Context API** (`SettingsContext`, `GenerationContext`) instead of inline global state.
+This refactored fork moves from a single monolithic HTML file to a **modular Parcel 2 project** (~60+ files across `src/`). The monolithic `styles.css` is split into 20 component-specific partials under `src/css/`, and global state is managed via **React Context API** (`SettingsContext`, `GenerationContext`) instead of inline global state.
 
 > **Note:** The server requires the `sqlite-zstd` extension (`libsqlite_zstd.so` / `sqlite_zstd.dll` / `libsqlite_zstd.dylib` depending on platform — the server auto-detects the correct one). Obtain it from [sqlite-zstd releases](https://github.com/phiresky/sqlite-zstd/releases) or build from source, then place it in `server/`.
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -2,7 +2,7 @@
 
 Miyapad is a web-based AI text generation interface focused on autocompletion/Text Completion API. It serves as a high-fidelity frontend client to interact with various local and remote LLM APIs, including llama.cpp, KoboldCPP, OpenAI-compatible APIs, DeepSeek, and AI Horde.
 
-The application features full local browser persistence via IndexedDB or centralized SQLite storage using an optional backend server. It supports rich features such as prompt templates, dynamic CSS themes, markdown previews, text-to-speech synthesis (TTS), token counts, interactive log-probability overlays, a keyboard-driven Quick Switcher for fast session switching, a dedicated modal for session management with search and metadata-based sorting, and the ability to pin/star sessions so they float to the top.
+The application features full local browser persistence via IndexedDB or centralized SQLite storage using an optional backend server. It supports rich features such as prompt templates, dynamic CSS themes, markdown previews, text-to-speech synthesis (TTS), token counts, interactive log-probability overlays, a keyboard-driven Quick Switcher for fast session switching, a dedicated modal for session management with search and metadata-based sorting, the ability to pin/star sessions so they float to the top, and a Connection Manager for saving and switching between connection presets (endpoint, API type, key, model) per-session.
 
 ## Documentation
 
@@ -13,7 +13,7 @@ The application features full local browser persistence via IndexedDB or central
 - [API Endpoints](api-endpoints.md) — Full REST API route reference
 - [Tokenization](tokenization.md) — Optional server-side tokenization with HuggingFace tokenizers
 - [Building & Running](building-and-running.md) — Dev server, production build, server CLI
-- [CSS Architecture](css.md) — 18 partial files, import order, theming, conventions
+- [CSS Architecture](css.md) — 20 partial files, import order, theming, conventions
 - [Development Conventions](development-conventions.md) — JSX-less components, CSS conventions, storage patterns
 - [Screenshot Capture](screenshot-capture.md) — Native screenshot feature for styled quote PNGs
 - [Session Tags](session-tags.md) — Freeform tags on sessions with inline editing and filtering

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -33,8 +33,8 @@ The `src/api/` directory implements a provider dispatch pattern for interfacing 
 
 | Provider | Module | Completion | Chat Completion | Models | Token Count |
 | :--- | :--- | :--- | :--- | :--- | :--- |
-| **llama.cpp** | `llamacpp.js` | `llamaCppCompletion` | — | `llamaCppModels` | `llamaCppTokenCount` |
-| **KoboldCPP** | `koboldcpp.js` | `koboldCppCompletion` | — | `koboldCppModels` | `koboldCppTokenCount` |
+| **llama.cpp** | `llamacpp.js` | `llamaCppCompletion` | — | — | `llamaCppTokenCount` |
+| **KoboldCPP** | `koboldcpp.js` | `koboldCppCompletion` | — | — | `koboldCppTokenCount` |
 | **OpenAI Compatible** | `openai.js` | `openaiCompletion` | `openaiChatCompletion` | `openaiModels` | host-aware |
 | **DeepSeek** | `deepseek.js` | `deepseekCompletion` | `deepseekChatCompletion` | `deepseekModels` | — |
 | **AI Horde** | `aihorde.js` | `aiHordeCompletion` | — | `aiHordeModels` | — |

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -19,7 +19,7 @@ graph TD
 - **`AbstractStorage` (`src/storage/AbstractStorage.js`)**: Base class that coordinates database requests. It implements a **500ms debounced save queue** (`enqueueSave`) to avoid excessive disk/DB writes during rapid user editing.
 - **`IndexedDBAdapter` (`src/storage/IndexedDBAdapter.js`)**: Communicates with the browser's IndexedDB engine (Database `MiyaPad`, version 5). Handles database upgrades, persistence requests, exports, and imports.
 - **`ServerDBAdapter` (`src/storage/ServerDBAdapter.js`)**: Converts database calls to HTTP POST requests hitting the Express server REST endpoints.
-- **`ConnectionStorage` (`src/storage/ConnectionStorage.js`)**: Extends `AbstractStorage` to persist named connection presets (endpoint, API type, API key, model, per-API options). Follows the same pattern as `ThemeStorage` — `performFullSave` replaces the entire connections object, and `loadConnections` loads all records on init. The `Connections` store is available in both IndexedDB (v5) and SQLite server-side.
+- **`ConnectionStorage` (`src/storage/ConnectionStorage.js`)**: Extends `AbstractStorage` to persist named connection presets (endpoint, API type, API key, model, per-API options). Follows the same pattern as `ThemeStorage` — `performFullSave` replaces the entire connections object (wrapped in try-catch with error dispatch), and `loadConnections` loads all records on init. The `Connections` store is available in both IndexedDB (v5) and SQLite server-side.
 - **Named Storage Optimization**: To prevent massive performance degradation, session titles and metadata are indexed separately in a `names` table/store as a JSON object `{name, created, modified, pinned, tags}`. This allows the dedicated Sessions Modal to quickly search, list, and sort sessions by creation or modification timestamps (and to float pinned sessions to the top) without pulling heavy compressed session history from the database.
 
 ## 2. Context APIs & State Management
@@ -47,6 +47,7 @@ The router in `src/api/index.js` dispatches calls based on the `endpointAPI` con
 - Logit bias uses OpenAI-compatible format
 - Chat completions include `thinking: { type: "disabled" }` to disable reasoning models
 - Default model: `deepseek-v4-flash` (configurable in UI)
+- `strict` mode and `chatAPI` toggle are configurable (same as OpenAI Compatible) and applied on connection select
 
 ## 4. Key Custom Hooks
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -12,17 +12,19 @@ graph TD
     SessionStorage[SessionStorage.js] --> AbstractStorage[AbstractStorage.js]
     TemplateStorage[TemplateStorage.js] --> AbstractStorage
     ThemeStorage[ThemeStorage.js] --> AbstractStorage
+    ConnectionStorage[ConnectionStorage.js] --> AbstractStorage
     AbstractStorage -->|calls| DBAdapter
 ```
 
 - **`AbstractStorage` (`src/storage/AbstractStorage.js`)**: Base class that coordinates database requests. It implements a **500ms debounced save queue** (`enqueueSave`) to avoid excessive disk/DB writes during rapid user editing.
-- **`IndexedDBAdapter` (`src/storage/IndexedDBAdapter.js`)**: Communicates with the browser's IndexedDB engine (Database `MiyaPad`, version 4). Handles database upgrades, persistence requests, exports, and imports.
+- **`IndexedDBAdapter` (`src/storage/IndexedDBAdapter.js`)**: Communicates with the browser's IndexedDB engine (Database `MiyaPad`, version 5). Handles database upgrades, persistence requests, exports, and imports.
 - **`ServerDBAdapter` (`src/storage/ServerDBAdapter.js`)**: Converts database calls to HTTP POST requests hitting the Express server REST endpoints.
+- **`ConnectionStorage` (`src/storage/ConnectionStorage.js`)**: Extends `AbstractStorage` to persist named connection presets (endpoint, API type, API key, model, per-API options). Follows the same pattern as `ThemeStorage` — `performFullSave` replaces the entire connections object, and `loadConnections` loads all records on init. The `Connections` store is available in both IndexedDB (v5) and SQLite server-side.
 - **Named Storage Optimization**: To prevent massive performance degradation, session titles and metadata are indexed separately in a `names` table/store as a JSON object `{name, created, modified, pinned, tags}`. This allows the dedicated Sessions Modal to quickly search, list, and sort sessions by creation or modification timestamps (and to float pinned sessions to the top) without pulling heavy compressed session history from the database.
 
 ## 2. Context APIs & State Management
 
-- **`SettingsContext` (`src/contexts/SettingsContext.js`)**: Holds global settings and generation hyperparameters (e.g., Temperature, Top-K, Min-P, Mirostat, Dry Sampler options, selected model endpoints, OpenAI keys, instruction templates, active themes, TTS voice settings).
+- **`SettingsContext` (`src/contexts/SettingsContext.js`)**: Holds global settings and generation hyperparameters (e.g., Temperature, Top-K, Min-P, Mirostat, Dry Sampler options, selected model endpoints, OpenAI keys, instruction templates, active themes, TTS voice settings). Also manages connection presets (`connections` via `useDBConnections`) and per-session connection binding (`selectedConnectionId` via `useSessionState`).
 - **`GenerationContext` (`src/contexts/GenerationContext.js`)**: Manages runtime generation and prompt state (e.g., prompt text chunks, total token count, generation speed, active abort controllers, undo/redo stacks, open modal states, and UI view toggles).
 
 ## 3. LLM Provider API Layer
@@ -31,8 +33,8 @@ The `src/api/` directory implements a provider dispatch pattern for interfacing 
 
 | Provider | Module | Completion | Chat Completion | Models | Token Count |
 | :--- | :--- | :--- | :--- | :--- | :--- |
-| **llama.cpp** | `llamacpp.js` | `llamaCppCompletion` | — | — | `llamaCppTokenCount` |
-| **KoboldCPP** | `koboldcpp.js` | `koboldCppCompletion` | — | — | `koboldCppTokenCount` |
+| **llama.cpp** | `llamacpp.js` | `llamaCppCompletion` | — | `llamaCppModels` | `llamaCppTokenCount` |
+| **KoboldCPP** | `koboldcpp.js` | `koboldCppCompletion` | — | `koboldCppModels` | `koboldCppTokenCount` |
 | **OpenAI Compatible** | `openai.js` | `openaiCompletion` | `openaiChatCompletion` | `openaiModels` | host-aware |
 | **DeepSeek** | `deepseek.js` | `deepseekCompletion` | `deepseekChatCompletion` | `deepseekModels` | — |
 | **AI Horde** | `aihorde.js` | `aiHordeCompletion` | — | `aiHordeModels` | — |

--- a/docs/backend-server.md
+++ b/docs/backend-server.md
@@ -2,15 +2,16 @@
 
 The server (`server/server.js` — entrypoint that loads modules from `lib/` and `routes/`) uses **SQLite3** combined with the precompiled **`sqlite-zstd` extension** to perform transparent, row-level Zstandard compression on database records.
 
-## Database Schema (v4)
+## Database Schema (v5)
 
-The database has five main tables:
+The database has six main tables:
 
-1. **`meta`**: Stores metadata (e.g., database schema `version = 4`).
+1. **`meta`**: Stores metadata (e.g., database schema `version = 5`).
 2. **`sessions`**: Stores main session data blobs. Uses column `session_data`.
 3. **`templates`**: Stores template configuration data. Uses column `template_data`.
 4. **`themes`**: Stores custom user CSS themes. Uses column `theme_data`.
-5. **`names`**: Stores lightweight key-to-metadata mapping `{name, created, modified, pinned}` (as JSON) for session listing, searching, sorting, and pinning.
+5. **`connections`**: Stores connection preset data (endpoint, API type, API key, model, per-API options). Uses column `connection_data`.
+6. **`names`**: Stores lightweight key-to-metadata mapping `{name, created, modified, pinned}` (as JSON) for session listing, searching, sorting, and pinning.
 
 ### Schema Column Constraints
 
@@ -19,6 +20,7 @@ The `sqlite-zstd` extension can experience index naming collisions if multiple t
 - `sessions` table uses **`session_data`**
 - `templates` table uses **`template_data`**
 - `themes` table uses **`theme_data`**
+- `connections` table uses **`connection_data`**
 
 ## Database Compaction & Compression Settings
 

--- a/docs/css.md
+++ b/docs/css.md
@@ -1,6 +1,6 @@
 # CSS Architecture
 
-Styles are organized into 19 partial files under `src/css/`, imported via `src/styles.css`. Each partial targets a specific component or logical group.
+Styles are organized into 20 partial files under `src/css/`, imported via `src/styles.css`. Each partial targets a specific component or logical group.
 
 ## Import Order
 
@@ -17,6 +17,7 @@ The ordering in `src/styles.css` is intentional — variables and base reset loa
 @import './css/_world-info.css';        # World Info / lorebook modal
 @import './css/_logit-bias.css';        # Logit bias editor modal
 @import './css/_horde.css';             # AI Horde status/settings
+@import './css/_connections.css';       # Connection Manager presets UI
 @import './css/_sidebar.css';           # Main sidebar layout
 @import './css/_sessions.css';          # Sessions management modal
 @import './css/_form-controls.css';     # Inputs, selects, labels, sliders
@@ -42,6 +43,7 @@ The ordering in `src/styles.css` is intentional — variables and base reset loa
 | `_world-info.css` | World Info entry editor: entry cards, key fields, filtering and search. |
 | `_logit-bias.css` | Logit bias slider and token selector interface. |
 | `_horde.css` | AI Horde integration panel: queue status, worker info, settings. |
+| `_connections.css` | Connection Manager modal: sidebar/detail layout, model list, error messages, mobile-responsive toggle. |
 | `_sidebar.css` | Main sidebar layout: width, collapse states, drag resize, scroll. |
 | `_sessions.css` | Sessions browser modal: session cards, search bar, sort controls, action buttons. |
 | `_form-controls.css` | Shared form element styling: text inputs, selects, checkboxes, radio buttons, range sliders, number inputs. |

--- a/docs/css.md
+++ b/docs/css.md
@@ -65,3 +65,4 @@ Dynamic themes are injected at runtime via a custom CSS injector element. Themes
 - When adding new styles, put them in the matching partial or create a new one if none fits.
 - Class names use kebab-case.
 - Avoid `!important` — use specificity or utility classes instead.
+- Use `overflow-wrap` over `word-break` for text wrapping — `word-break: break-word` is deprecated.

--- a/docs/development-conventions.md
+++ b/docs/development-conventions.md
@@ -37,6 +37,14 @@ CHANGELOG.md is manually curated. After each non-`docs` or `ci` commit, add an e
 - Problem that was affecting the user's experience
 ```
 
+## Safe Property Checks
+
+Use `Object.hasOwn(obj, prop)` (ES2022+) instead of `obj.hasOwnProperty(prop)` to avoid breakage if the object contains an own property named `hasOwnProperty`.
+
+## Deep Cloning
+
+Use `structuredClone` for deep copying plain data objects instead of shallow spread or `JSON.parse(JSON.stringify(...))`.
+
 ## CSS Conventions
 
 See [CSS Architecture](css.md) for full documentation. Key points:

--- a/docs/development-conventions.md
+++ b/docs/development-conventions.md
@@ -25,7 +25,7 @@ Always run `npm run build` after editing any source file (`src/` or `server/`) a
 
 ## Changelog Maintenance
 
-CHANGELOG.md is manually curated. After each non-`docs` commit, add an entry under the `[???]` unreleased heading in `CHANGELOG.md` with the appropriate type subheading (`### Added`, `### Fixed`, `### Changed`, `### Removed`). The `[???]` placeholder is replaced with the actual version number at release time. Only include changes that affect the end user — omit `ci` and other internal changes.
+CHANGELOG.md is manually curated. After each non-`docs` or `ci` commit, add an entry under the `[???]` unreleased heading in `CHANGELOG.md` with the appropriate type subheading (`### Added`, `### Fixed`, `### Changed`, `### Removed`). The `[???]` placeholder is replaced with the actual version number at release time. Only include changes that affect the end user — omit internal changes.
 
 ```markdown
 ## [???] - unreleased

--- a/docs/development-conventions.md
+++ b/docs/development-conventions.md
@@ -25,16 +25,16 @@ Always run `npm run build` after editing any source file (`src/` or `server/`) a
 
 ## Changelog Maintenance
 
-CHANGELOG.md is manually curated. After each non-`docs` or `ci` commit, add an entry under the `[???]` unreleased heading in `CHANGELOG.md` with the appropriate type subheading (`### Added`, `### Fixed`, `### Changed`, `### Removed`). The `[???]` placeholder is replaced with the actual version number at release time. Only include changes that affect the end user — omit internal changes.
+CHANGELOG.md is manually curated. After each non-`docs` or `ci` commit, add an entry under the `[???]` unreleased heading in `CHANGELOG.md` with the appropriate type subheading (`### Added`, `### Fixed`, `### Changed`, `### Removed`). The `[???]` placeholder is replaced with the actual version number at release time. Only include changes that affect the end user — omit internal changes. Entries should be written in user-friendly language, describing the feature or fix from the user's perspective without technical implementation details.
 
 ```markdown
 ## [???] - unreleased
 
 ### Added
-- New feature description
+- New feature that the user can interact with
 
 ### Fixed
-- Bug fix description
+- Problem that was affecting the user's experience
 ```
 
 ## CSS Conventions

--- a/docs/project-structure.md
+++ b/docs/project-structure.md
@@ -31,7 +31,7 @@ miyapad/
     ├── api/                       # API modules for backends (llama.cpp, KoboldCPP, OpenAI, DeepSeek, AI Horde)
     ├── components/                # React components (Modals, Sidebar, controls, icons)
     ├── contexts/                  # SettingsContext and GenerationContext
-    ├── css/                       # CSS partials (19 files, imported by styles.css)
+    ├── css/                       # CSS partials (20 files, imported by styles.css)
     ├── defaults/                  # Hardcoded defaults for presets, prompts, themes
     ├── hooks/                     # Custom hooks (generation logic, prompt builders, etc.)
     ├── storage/                   # Storage adapters (IndexedDB, Server REST API, storages)

--- a/server/lib/database.js
+++ b/server/lib/database.js
@@ -184,6 +184,7 @@ const runMigrationToV4 = (db) => {
                 await migrateTableToZstd('sessions');
                 await migrateTableToZstd('templates');
                 await migrateTableToZstd('themes');
+                await migrateTableToZstd('connections');
 
                 console.log("Running initial zstd incremental maintenance (training dictionaries)...");
                 await new Promise((res, rej) => db.run(`SELECT zstd_incremental_maintenance(null, 1)`, (err) => err ? rej(err) : res()));
@@ -342,9 +343,11 @@ const initDatabase = (storagePath) => {
                             const sessionCol = getColumnName('sessions');
                             const templateCol = getColumnName('templates');
                             const themeCol = getColumnName('themes');
+                            const connectionCol = getColumnName('connections');
                             db.run(`CREATE TABLE IF NOT EXISTS sessions (key TEXT PRIMARY KEY, ${sessionCol} BLOB)`);
                             db.run(`CREATE TABLE IF NOT EXISTS templates (key TEXT PRIMARY KEY, ${templateCol} BLOB)`);
                             db.run(`CREATE TABLE IF NOT EXISTS themes (key TEXT PRIMARY KEY, ${themeCol} BLOB)`);
+                            db.run(`CREATE TABLE IF NOT EXISTS connections (key TEXT PRIMARY KEY, ${connectionCol} BLOB)`);
                             db.run(`CREATE TABLE IF NOT EXISTS meta (key TEXT PRIMARY KEY, value TEXT)`, (err) => {
                                 if (err) rej(err);
                                 else res();
@@ -375,7 +378,8 @@ const initDatabase = (storagePath) => {
                     await Promise.all([
                         enableTransparentCompressionIfMissing(db, 'sessions'),
                         enableTransparentCompressionIfMissing(db, 'templates'),
-                        enableTransparentCompressionIfMissing(db, 'themes')
+                        enableTransparentCompressionIfMissing(db, 'themes'),
+                        enableTransparentCompressionIfMissing(db, 'connections')
                     ]);
 
                     await new Promise((res, rej) => {

--- a/server/lib/utils.js
+++ b/server/lib/utils.js
@@ -16,6 +16,7 @@ const getColumnName = (storeName) => {
     if (storeName === 'sessions') return 'session_data';
     if (storeName === 'templates') return 'template_data';
     if (storeName === 'themes') return 'theme_data';
+    if (storeName === 'connections') return 'connection_data';
     return 'data';
 };
 
@@ -24,7 +25,7 @@ const normalizeStoreName = (storeName) => {
         return 'sessions';
     }
     const normalized = storeName.split(' ')[0].toLowerCase();
-    if (['sessions', 'templates', 'names', 'themes'].includes(normalized)) {
+    if (['sessions', 'templates', 'names', 'themes', 'connections'].includes(normalized)) {
         return normalized;
     }
     return null;

--- a/src/App.js
+++ b/src/App.js
@@ -3,15 +3,17 @@ import { SettingsProvider } from './contexts/SettingsContext.js';
 import { GenerationProvider } from './contexts/GenerationContext.js';
 import { AppLayout } from './AppLayout.js';
 
-export function App({ sessionStorage, templateStorage, themeStorage, useSessionState, useDBTemplates, useDBThemes, isMiyapadEndpoint }) {
+export function App({ sessionStorage, templateStorage, themeStorage, connectionStorage, useSessionState, useDBTemplates, useDBThemes, useDBConnections, isMiyapadEndpoint }) {
 	return html`
 		<${SettingsProvider}
 			sessionStorage=${sessionStorage}
 			templateStorage=${templateStorage}
 			themeStorage=${themeStorage}
+			connectionStorage=${connectionStorage}
 			useSessionState=${useSessionState}
 			useDBTemplates=${useDBTemplates}
 			useDBThemes=${useDBThemes}
+			useDBConnections=${useDBConnections}
 			isMiyapadEndpoint=${isMiyapadEndpoint}
 		>
 			<${GenerationProvider} useSessionState=${useSessionState}>

--- a/src/components/Modal.js
+++ b/src/components/Modal.js
@@ -7,6 +7,7 @@ export function Modal({ isOpen, onClose, title, description, children, ...props 
 	const prevIsOpen = useRef(isOpen);
 	const closeTimerRef = useRef(null);
 	const isClosing = !isOpen && internalVisible;
+	const mouseDownOnBackground = useRef(false);
 
 	useEffect(() => {
 		if (isOpen) {
@@ -47,10 +48,26 @@ export function Modal({ isOpen, onClose, title, description, children, ...props 
 		return null;
 	}
 
+	const handleOverlayMouseDown = (e) => {
+		mouseDownOnBackground.current = true;
+	};
+
+	const handleOverlayClick = (e) => {
+		if (mouseDownOnBackground.current) {
+			onClose();
+		}
+		mouseDownOnBackground.current = false;
+	};
+
 	return html`
-		<div className="modal-overlay ${isClosing ? 'closing' : ''}" onClick=${onClose}>
+		<div className="modal-overlay ${isClosing ? 'closing' : ''}"
+			onMouseDown=${handleOverlayMouseDown}
+			onClick=${handleOverlayClick}>
 			<div className="modal-container">
-				<div className="modal ${isClosing ? 'closing' : ''}" onClick=${(e) => e.stopPropagation()} ...${props}>
+				<div className="modal ${isClosing ? 'closing' : ''}"
+					onClick=${(e) => e.stopPropagation()}
+					onMouseDown=${(e) => e.stopPropagation()}
+					...${props}>
 					<div class="modal-title">${title}</div>
 					${ description=="" ? false : html`<div style=${{ whiteSpace: 'pre-line' }} class='modal-desc'>${description}</div>` }
 					<hr/>

--- a/src/components/Modal.js
+++ b/src/components/Modal.js
@@ -66,7 +66,7 @@ export function Modal({ isOpen, onClose, title, description, children, ...props 
 			<div className="modal-container">
 				<div className="modal ${isClosing ? 'closing' : ''}"
 					onClick=${(e) => e.stopPropagation()}
-					onMouseDown=${(e) => e.stopPropagation()}
+					onMouseDown=${(e) => { e.stopPropagation(); mouseDownOnBackground.current = false; }}
 					...${props}>
 					<div class="modal-title">${title}</div>
 					${ description=="" ? false : html`<div style=${{ whiteSpace: 'pre-line' }} class='modal-desc'>${description}</div>` }

--- a/src/components/Modals.js
+++ b/src/components/Modals.js
@@ -20,6 +20,7 @@ import { InstructModal } from './modals/InstructModal.js';
 import { ThemeManagerModal } from './modals/ThemeManagerModal.js';
 import { AIHordeSettingsModal } from './modals/AIHordeSettingsModal.js';
 import { CompressionInfoModal } from './modals/CompressionInfoModal.js';
+import { ConnectionManagerModal } from './modals/ConnectionManagerModal.js';
 import { SessionsModal } from './modals/SessionsModal.js';
 import { QuickSwitcher } from './QuickSwitcher.js';
 import { EditorContextMenu } from './EditorContextMenu.js';
@@ -38,7 +39,8 @@ export function Modals({ toggleModal, currentThemeName, setCurrentThemeName, all
 		screenshotLineHeight, setScreenshotLineHeight,
 		screenshotFontColor, setScreenshotFontColor,
 		screenshotAiTextColor, setScreenshotAiTextColor,
-		screenshotModelAvatarUrl, setScreenshotModelAvatarUrl
+		screenshotModelAvatarUrl, setScreenshotModelAvatarUrl,
+		connections, setConnections, selectedConnectionId
 	} = useSettings();
 	const { cancel, modalState, closeModal, instructModalState, setInstructModalState, promptArea, predict, lastError, sessionEndpointConnecting, predictStartTokens, tokens, stoppingStringsError, drySequenceBreakersError, bannedTokensError, contextMenuState, setContextMenuState, setTriggerPredict, sessionEndpointError, setRejectedAPIKey } = useGeneration();
 
@@ -329,6 +331,13 @@ export function Modals({ toggleModal, currentThemeName, setCurrentThemeName, all
 		<${CompressionInfoModal}
 			isOpen=${modalState.compression}
 			closeModal=${() => closeModal("compression")}/>
+
+		<${ConnectionManagerModal}
+			isOpen=${modalState.connections}
+			closeModal=${() => closeModal("connections")}
+			connections=${connections}
+			setConnections=${setConnections}
+			activeConnectionId=${selectedConnectionId}/>
 
 		<${SessionsModal}
 			isOpen=${modalState.sessions}

--- a/src/components/Sidebar.js
+++ b/src/components/Sidebar.js
@@ -275,7 +275,7 @@ export function Sidebar({ sidebarRef, toggleModal, currentThemeName, setCurrentT
 						<${SVG_Settings} style=${{ 'width':'.95em','transform':'translate(-50%, -45%)' }}/>
 					</button>
 				</div>
-				${(selectedConnectionId == 'custom') && html`
+				${(selectedConnectionId === 'custom') && html`
 				<${InputBox} label="Server"
 					className=${isMixedContent() ? 'mixed-content' : ''}
 					tooltip=${isMixedContent() ? 'This URL might be blocked due to mixed content. If the prediction fails, download miyapad.html and run it locally.' : ''}

--- a/src/components/Sidebar.js
+++ b/src/components/Sidebar.js
@@ -33,7 +33,8 @@ export function Sidebar({ sidebarRef, toggleModal, currentThemeName, setCurrentT
 		postSamplingProbs, setPostSamplingProbs, showPromptPreview, setShowPromptPreview,
 		promptPreviewTokens, setPromptPreviewTokens, templates, selectedTemplate, setSelectedTemplate,
 		isMiyapadEndpoint, sessionStorage, chatMode, setChatMode, seed, setSeed, contextLength, setContextLength,
-		memoryTokens, authorNoteTokens, authorNoteDepth, templateList, tokenHighlightMode
+		memoryTokens, authorNoteTokens, authorNoteDepth, templateList, tokenHighlightMode,
+		connections, setConnections, selectedConnectionId, setSelectedConnectionId
 	} = useSettings();
 
 	const {
@@ -190,6 +191,28 @@ export function Sidebar({ sidebarRef, toggleModal, currentThemeName, setCurrentT
 		elem.scrollTop = scrollTop;
 	};
 
+	const handleApplyConnection = (conn) => {
+		setEndpointAPI(conn.api);
+		if (conn.api !== API_AI_HORDE) {
+			setEndpoint(conn.endpoint);
+		}
+		setEndpointAPIKey(conn.key || "");
+		setEndpointModel(conn.model || "");
+		if (conn.api === API_LLAMA_CPP) {
+			setPostSamplingProbs(conn.postSamplingProbs ?? true);
+		}
+		if (conn.api === API_OPENAI_COMPAT) {
+			setOpenaiPresets(conn.strict ?? false);
+			setUseChatAPI(conn.chatAPI ?? false);
+		}
+	};
+
+	useEffect(() => {
+		if (selectedConnectionId !== 'custom' && connections[selectedConnectionId]) {
+			handleApplyConnection(connections[selectedConnectionId]);
+		}
+	}, [selectedConnectionId]);
+
 	function isMixedContent() {
 		const isHttps = window.location.protocol === 'https:';
 		let url;
@@ -227,6 +250,32 @@ export function Sidebar({ sidebarRef, toggleModal, currentThemeName, setCurrentT
 				Manage Sessions
 			</button>
 			<${CollapsibleGroup} label="Parameters" expanded>
+				<div className="buttons instructTemplateSidebar">
+					<${SelectBox}
+						label="Connection Preset"
+						value=${selectedConnectionId}
+						options=${() => [
+							{ name: 'Custom (Inline Edit)', value: 'custom' },
+							...Object.entries(connections)
+							   .filter(([_, c]) => c.enabled)
+							   .map(([id, c]) => ({ name: c.name, value: id }))
+						]}
+						onValueChange=${(val) => {
+							if (val !== 'custom' && connections[val]) {
+								handleApplyConnection(connections[val]);
+							}
+							setSelectedConnectionId(val);
+						}}
+					/>
+					<button
+						onClick=${() => toggleModal("connections")}
+						title="Manage Connections"
+						className="symbol-button"
+						style=${{ padding: 0 }}>
+						<${SVG_Settings} style=${{ 'width':'.95em','transform':'translate(-50%, -45%)' }}/>
+					</button>
+				</div>
+				${(selectedConnectionId == 'custom') && html`
 				<${InputBox} label="Server"
 					className=${isMixedContent() ? 'mixed-content' : ''}
 					tooltip=${isMixedContent() ? 'This URL might be blocked due to mixed content. If the prediction fails, download miyapad.html and run it locally.' : ''}
@@ -288,6 +337,9 @@ export function Sidebar({ sidebarRef, toggleModal, currentThemeName, setCurrentT
 						<${Checkbox} label="Chat Completions API"
 							title="If enabled, the chat API endpoint will be used, and the prompt will be split into chat messages based on the delimiters defined in the selected instruct template."
 							disabled=${!!cancel} value=${useChatAPI} onValueChange=${setUseChatAPI}/>`}
+				`}
+			`}
+				${endpointAPI != API_AI_HORDE && html`
 					<${Checkbox} label="Token Streaming"
 						disabled=${!!cancel} value=${useTokenStreaming} onValueChange=${setUseTokenStreaming}/>
 					<${Checkbox} label="Disable Logprobs"

--- a/src/components/Sidebar.js
+++ b/src/components/Sidebar.js
@@ -201,7 +201,7 @@ export function Sidebar({ sidebarRef, toggleModal, currentThemeName, setCurrentT
 		if (conn.api === API_LLAMA_CPP) {
 			setPostSamplingProbs(conn.postSamplingProbs ?? true);
 		}
-		if (conn.api === API_OPENAI_COMPAT) {
+		if (conn.api === API_OPENAI_COMPAT || conn.api === API_DEEPSEEK) {
 			setOpenaiPresets(conn.strict ?? false);
 			setUseChatAPI(conn.chatAPI ?? false);
 		}

--- a/src/components/icons/index.js
+++ b/src/components/icons/index.js
@@ -238,6 +238,19 @@ export const SVG_Camera = ({ ...props }) => {
   `;
 };
 
+export const SVG_CheckOn = ({...props}) => {
+	return html`
+	<${SVG} width="1em" height="1em" viewBox="0 0 24 24" ...${props}>
+		<path fill="var(--color-light)" d="M19 3H5c-1.11 0-2 .9-2 2v14c0 1.1.89 2 2 2h14c1.11 0 2-.9 2-2V5c0-1.1-.89-2-2-2zm-9 14l-5-5 1.41-1.41L10 14.17l7.59-7.59L19 8l-9 9z"/>
+	</${SVG}>
+`};
+export const SVG_CheckOff = ({...props}) => {
+	return html`
+	<${SVG} width="1em" height="1em" viewBox="0 0 24 24" ...${props}>
+		<path fill="var(--color-light)" d="M19 5v14H5V5h14m0-2H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2z"/>
+	</${SVG}>
+`};
+
 export const SVG_SplitView = ({ ...props }) => {
   return html`
     <${SVG}

--- a/src/components/modals/ConnectionManagerModal.js
+++ b/src/components/modals/ConnectionManagerModal.js
@@ -26,6 +26,7 @@ function GenericConnectionSettings({ connection, updateConnection }) {
 	const fetchModels = async () => {
 		setIsFetching(true);
 		setError(null);
+		if (acRef.current) acRef.current.abort();
 		const ac = new AbortController();
 		acRef.current = ac;
 		try {
@@ -174,6 +175,7 @@ function AIHordeConnectionSettings({ connection, updateConnection }) {
 	const fetchModels = async () => {
 		setIsFetching(true);
 		setError(null);
+		if (acRef.current) acRef.current.abort();
 		const ac = new AbortController();
 		acRef.current = ac;
 		try {

--- a/src/components/modals/ConnectionManagerModal.js
+++ b/src/components/modals/ConnectionManagerModal.js
@@ -356,7 +356,9 @@ export function ConnectionManagerModal({ isOpen, closeModal, connections, setCon
 			return;
 		}
 		const newId = crypto.randomUUID();
-		const newConnection = { ...conn, id: newId, name: `${conn.name} (Copy)` };
+		const newConnection = structuredClone(conn);
+		newConnection.id = newId;
+		newConnection.name = `${conn.name} (Copy)`;
 		setConnections(prev => ({ ...prev, [newId]: newConnection }));
 		setSelectedId(newId);
 		setMobileShowDetails(true);

--- a/src/components/modals/ConnectionManagerModal.js
+++ b/src/components/modals/ConnectionManagerModal.js
@@ -336,7 +336,7 @@ export function ConnectionManagerModal({ isOpen, closeModal, connections, setCon
 			id: newId,
 			name: newName,
 			api: API_OPENAI_COMPAT,
-			endpoint: "https://127.0.0.1/v1",
+			endpoint: "http://127.0.0.1:8080/v1",
 			key: "",
 			enabled: true,
 			models: [],

--- a/src/components/modals/ConnectionManagerModal.js
+++ b/src/components/modals/ConnectionManagerModal.js
@@ -1,0 +1,532 @@
+import { html } from 'htm/react';
+import { useState, useEffect, useLayoutEffect, useRef } from 'react';
+import { Modal } from '../Modal.js';
+import { InputBox } from '../controls/InputBox.js';
+import { SelectBox } from '../controls/SelectBox.js';
+import { Checkbox } from '../controls/Checkbox.js';
+import { SVG_Trash, SVG_ShowKey, SVG_HideKey, SVG_Regen, SVG_CheckOn, SVG_CheckOff } from '../icons/index.js';
+import { API_LLAMA_CPP, API_KOBOLD_CPP, API_OPENAI_COMPAT, API_AI_HORDE, API_DEEPSEEK } from '../../constants.js';
+import { getModels } from '../../api/index.js';
+
+function GenericConnectionSettings({ connection, updateConnection }) {
+	const [showKey, setShowKey] = useState(false);
+	const [isFetching, setIsFetching] = useState(false);
+	const [error, setError] = useState(null);
+	const [search, setSearch] = useState("");
+	const acRef = useRef(null);
+
+	useEffect(() => {
+		return () => {
+			if (acRef.current) {
+				acRef.current.abort();
+			}
+		};
+	}, []);
+
+	const fetchModels = async () => {
+		setIsFetching(true);
+		setError(null);
+		const ac = new AbortController();
+		acRef.current = ac;
+		try {
+			const models = await getModels({
+				endpoint: connection.endpoint,
+				endpointAPI: connection.api,
+				endpointAPIKey: connection.key,
+				signal: ac.signal
+			});
+
+			if (Array.isArray(models)) {
+				updateConnection('models', models);
+			}
+		} catch (e) {
+			if (e.name === 'AbortError') return;
+			console.error(e);
+			setError(e.message || e.toString());
+		} finally {
+			setIsFetching(false);
+		}
+	};
+
+	const filteredModels = connection.models
+		? connection.models.filter(m => m.toLowerCase().includes(search.toLowerCase()))
+		: [];
+
+	const iconCheck = html`<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3"><polyline points="20 6 9 17 4 12"></polyline></svg>`;
+
+	return html`
+		<div className="connection-content-scroll">
+			<${InputBox} label="Connection Name"
+				value=${connection.name}
+				onInput=${(e) => updateConnection('name', e.target.value)}
+				onValueChange=${() => {}}
+			/>
+
+			<${InputBox} label="Base URL"
+				value=${connection.endpoint}
+				onValueChange=${(val) => updateConnection('endpoint', val)}
+			/>
+
+			${connection.api !== API_LLAMA_CPP && connection.api !== API_KOBOLD_CPP && html`
+				<div className="hbox-flex" style=${{"flex-wrap": "unset"}}>
+					<${InputBox} label="API Key" type=${showKey ? 'text' : 'password'}
+						value=${connection.key}
+						onValueChange=${(val) => updateConnection('key', val)}
+					/>
+					<button title=${showKey ? "Hide" : "Show"}
+						className="eye-button"
+						onClick=${() => setShowKey(!showKey)}>
+						${!showKey ? html`<${SVG_ShowKey}/>` : html`<${SVG_HideKey}/>`}
+					</button>
+				</div>
+			`}
+
+			${connection.api === API_LLAMA_CPP && html`
+				<${Checkbox} label="Post Sampling Probs"
+					title="This returns the probabilities after applying the sampling chain. Note that disabling this will significantly reduce generation speed."
+					value=${connection.postSamplingProbs ?? true}
+					onValueChange=${(val) => updateConnection('postSamplingProbs', val)}
+				/>
+			`}
+${(connection.api === API_OPENAI_COMPAT || connection.api === API_DEEPSEEK) && html`
+				<${Checkbox} label="Strict API"
+					title="If enabled, non-standard fields won't be included in API requests."
+					value=${connection.strict ?? false}
+					onValueChange=${(val) => updateConnection('strict', val)}
+				/>
+				<${Checkbox} label="Chat Completions API"
+					title="If enabled, the chat API endpoint will be used, and the prompt will be split into chat messages based on the delimiters defined in the selected instruct template."
+					value=${connection.chatAPI ?? false}
+					onValueChange=${(val) => updateConnection('chatAPI', val)}
+				/>
+			`}
+
+			<${InputBox} label="Selected Model"
+				value=${connection.model || ""}
+				onInput=${(e) => updateConnection('model', e.target.value)}
+				onValueChange=${() => {}}
+			/>
+
+			<div class="connection-models-wrapper">
+				<div class="connection-models-header">
+					<label style=${{'padding-left': '8px'}}>Available Models</label>
+					<button className="connection-action-btn"
+						style=${{padding: '0 4px', fontSize: '0.8em'}}
+						onClick=${fetchModels}
+						disabled=${isFetching}>
+						<${SVG_Regen} style=${{width: '1em'}}/>
+						${isFetching ? 'Refreshing...' : 'Refresh List'}
+					</button>
+				</div>
+
+				${error && html`
+					<div className="connection-error-msg">
+						<b>Connection Error:</b><br/>
+						${error}
+					</div>
+				`}
+
+				<div className="model-search-box">
+					<${InputBox}
+						placeholder="Filter list..."
+						value=${search}
+						onInput=${(e) => setSearch(e.target.value)}
+						onValueChange=${() => {}}
+					/>
+				</div>
+
+				<div className="connection-model-list">
+					${(connection.models && connection.models.length > 0)
+						? filteredModels.map(m => html`
+							<div className="connection-model-item ${connection.model === m ? 'selected' : ''}"
+								onClick=${() => updateConnection('model', m)}>
+								<span>${m}</span>
+								${connection.model === m ? iconCheck : ''}
+							</div>
+						`)
+						: html`<div className="connection-models-empty">
+							${isFetching ? 'Fetching models...' : 'No models found. Click Refresh.'}
+						</div>`}
+				</div>
+			</div>
+		</div>
+	`;
+}
+
+function AIHordeConnectionSettings({ connection, updateConnection }) {
+	const [showKey, setShowKey] = useState(false);
+	const [isFetching, setIsFetching] = useState(false);
+	const [error, setError] = useState(null);
+	const [search, setSearch] = useState("");
+	const [availableModels, setAvailableModels] = useState([]);
+	const acRef = useRef(null);
+
+	useEffect(() => {
+		return () => {
+			if (acRef.current) {
+				acRef.current.abort();
+			}
+		};
+	}, []);
+
+	const selectedModels = connection.model ? connection.model.split(',').map(s => s.trim()).filter(Boolean) : [];
+
+	const fetchModels = async () => {
+		setIsFetching(true);
+		setError(null);
+		const ac = new AbortController();
+		acRef.current = ac;
+		try {
+			const res = await fetch(`https://aihorde.net/api/v2/status/models?type=text`, {
+				method: 'GET',
+				headers: { 'Content-Type': 'application/json' },
+				signal: ac.signal,
+			});
+
+			if (!res.ok) throw new Error(`HTTP ${res.status}`);
+
+			const modelData = (await res.json()).filter(model => model.type === "text");
+			modelData.sort((a, b) => b.count - a.count || a.eta - b.eta);
+			setAvailableModels(modelData);
+		} catch (e) {
+			if (e.name === 'AbortError') return;
+			console.error(e);
+			setError(e.message || e.toString());
+		} finally {
+			setIsFetching(false);
+		}
+	};
+
+	useEffect(() => {
+		fetchModels();
+	}, []);
+
+	const toggleModel = (modelName) => {
+		const currentSet = new Set(selectedModels);
+		if (currentSet.has(modelName)) {
+			currentSet.delete(modelName);
+		} else {
+			currentSet.add(modelName);
+		}
+		updateConnection('model', Array.from(currentSet).join(', '));
+	};
+
+	const filteredModels = availableModels.filter(m => m.name.toLowerCase().includes(search.toLowerCase()));
+
+	return html`
+		<div className="connection-content-scroll">
+			<${InputBox} label="Connection Name"
+				value=${connection.name}
+				onInput=${(e) => updateConnection('name', e.target.value)}
+				onValueChange=${() => {}}
+			/>
+
+			<div className="hbox-flex" style=${{"flex-wrap": "unset"}}>
+				<${InputBox} label="AI Horde API Key" type=${showKey ? 'text' : 'password'}
+					placeholder="Enter a key (or leave empty for anonymous use)"
+					value=${connection.key}
+					onValueChange=${(val) => updateConnection('key', val)}
+				/>
+				<button title=${showKey ? "Hide" : "Show"}
+					className="eye-button"
+					onClick=${() => setShowKey(!showKey)}>
+					${!showKey ? html`<${SVG_ShowKey}/>` : html`<${SVG_HideKey}/>`}
+				</button>
+			</div>
+			<div style=${{fontSize: '0.8em', marginTop: '-4px'}}>
+				<a href="https://aihorde.net/register" target="_blank" rel="noopener noreferrer">Need a Key? (Register New User)</a>
+			</div>
+
+			<${InputBox} label="Selected Models"
+				placeholder="Select from the list below"
+				value=${connection.model || ""}
+				onInput=${(e) => updateConnection('model', e.target.value)}
+				onValueChange=${() => {}}
+				readOnly
+			/>
+
+			<div class="connection-models-wrapper">
+				<div class="connection-models-header">
+					<label style=${{'padding-left': '8px'}}>Available Models</label>
+					<button className="connection-action-btn"
+						style=${{padding: '0 4px', fontSize: '0.8em'}}
+						onClick=${fetchModels}
+						disabled=${isFetching}>
+						<${SVG_Regen} style=${{width: '1em'}}/>
+						${isFetching ? 'Refreshing...' : 'Refresh List'}
+					</button>
+				</div>
+
+				${error && html`
+					<div className="connection-error-msg">
+						<b>Connection Error:</b><br/>
+						${error}
+					</div>
+				`}
+
+				<div className="model-search-box">
+					<${InputBox}
+						placeholder="Filter models..."
+						value=${search}
+						onInput=${(e) => setSearch(e.target.value)}
+						onValueChange=${() => {}}
+					/>
+				</div>
+
+				<div className="connection-model-list">
+					${(availableModels.length > 0)
+						? filteredModels.map(m => {
+							const isSelected = selectedModels.includes(m.name);
+							return html`
+								<div className="connection-model-item"
+									style=${{flexDirection: 'column', alignItems: 'stretch', gap: '4px'}}
+									onClick=${() => toggleModel(m.name)}>
+
+									<div style=${{display: 'flex', justifyContent: 'space-between', alignItems: 'center'}}>
+										<span style=${{fontWeight: 'bold'}}>${m.name}</span>
+										<input type="checkbox" checked=${isSelected} readOnly style=${{pointerEvents: 'none'}}/>
+									</div>
+
+									<div style=${{display: 'flex', gap: '1em', fontSize: '0.85em', opacity: 0.8}}>
+										<span>ETA: ${m.eta}s</span>
+										<span>Queue: ${m.queued}</span>
+										<span>Workers: ${m.count}</span>
+									</div>
+								</div>
+							`
+						})
+						: html`<div className="connection-models-empty">
+							${isFetching ? 'Fetching models...' : 'No models found. Click Refresh.'}
+						</div>`}
+				</div>
+			</div>
+		</div>
+	`;
+}
+
+export function ConnectionManagerModal({ isOpen, closeModal, connections, setConnections, activeConnectionId }) {
+	const [selectedId, setSelectedId] = useState(null);
+	const [mobileShowDetails, setMobileShowDetails] = useState(false);
+
+	useLayoutEffect(() => {
+		if (isOpen) {
+			if (selectedId !== 'custom' && selectedId !== activeConnectionId) {
+				setSelectedId(activeConnectionId);
+			} else if (!selectedId && Object.keys(connections).length > 0) {
+				setSelectedId(Object.keys(connections)[0]);
+			}
+			setMobileShowDetails(false);
+		}
+	}, [isOpen]);
+
+	const handleNewConnection = () => {
+		const newId = crypto.randomUUID();
+
+		let counter = 1;
+		let newName = `New Connection #${counter}`;
+		const existingNames = Object.values(connections).map(c => c.name);
+		while (existingNames.includes(newName)) {
+			counter++;
+			newName = `New Connection #${counter}`;
+		}
+
+		const newConnection = {
+			id: newId,
+			name: newName,
+			api: API_OPENAI_COMPAT,
+			endpoint: "https://127.0.0.1/v1",
+			key: "",
+			enabled: true,
+			models: [],
+			model: "",
+			postSamplingProbs: true,
+			strict: false,
+			chatAPI: false,
+		};
+		setConnections(prev => ({ ...prev, [newId]: newConnection }));
+		setSelectedId(newId);
+		setMobileShowDetails(true);
+	};
+
+	const handleCloneConnection = (id) => {
+		const conn = connections[id];
+		if (!conn) {
+			return;
+		}
+		const newId = crypto.randomUUID();
+		const newConnection = { ...conn, id: newId, name: `${conn.name} (Copy)` };
+		setConnections(prev => ({ ...prev, [newId]: newConnection }));
+		setSelectedId(newId);
+		setMobileShowDetails(true);
+	};
+
+	const handleDeleteConnection = (id) => {
+		if (id === activeConnectionId) {
+			return;
+		}
+		if (!confirm("Are you sure you want to delete this connection?")) {
+			return;
+		}
+		setConnections(prev => {
+			const next = { ...prev };
+			delete next[id];
+			return next;
+		});
+		if (selectedId === id) {
+			setSelectedId(null);
+			setMobileShowDetails(false);
+		}
+	};
+
+	const handleUpdateConnection = (id, field, value) => {
+		setConnections(prev => ({
+			...prev,
+			[id]: { ...prev[id], [field]: value }
+		}));
+	};
+
+	const updateCurrentConnection = (field, value) => {
+		if (!selectedId) {
+			return;
+		}
+		handleUpdateConnection(selectedId, field, value);
+	};
+
+	const updateCurrentConnectionType = (val) => {
+		if (!selectedId) {
+			return;
+		}
+
+		const updates = {
+			api: val,
+			models: [],
+			model: "",
+			key: ""
+		};
+
+		if (val === API_AI_HORDE) {
+			updates.endpoint = "https://aihorde.net/api";
+		} else if (val === API_LLAMA_CPP) {
+			updates.endpoint = "http://127.0.0.1:8080";
+		} else if (val === API_KOBOLD_CPP) {
+			updates.endpoint = "http://127.0.0.1:5001/api";
+		} else if (val === API_DEEPSEEK) {
+			updates.endpoint = "https://api.deepseek.com";
+		}
+
+		setConnections(prev => ({
+			...prev,
+			[selectedId]: { ...prev[selectedId], ...updates }
+		}));
+	}
+
+	const currentConn = connections[selectedId];
+	const isActiveConnection = selectedId === activeConnectionId;
+
+	const iconBack = html`<svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M15 18l-6-6 6-6"/></svg>`;
+
+	return html`
+		<${Modal} isOpen=${isOpen} onClose=${closeModal}
+			title="Connections"
+			description="Manage your AI connection presets.">
+
+			<div className="connection-modal-layout ${mobileShowDetails ? 'mobile-show-details' : ''}">
+				<div className="connection-sidebar">
+					<div className="connection-sidebar-header">
+						<span>Your connections</span>
+						<button onClick=${handleNewConnection} title="Add New">+ New</button>
+					</div>
+					<div className="connection-list">
+						${Object.entries(connections).map(([id, conn]) => html`
+							<div key=${id}
+								className="connection-item ${selectedId === id ? 'selected' : ''} ${conn.enabled ? 'enabled' : ''}"
+								onClick=${() => {
+									setSelectedId(id);
+									setMobileShowDetails(true);
+								}}>
+								<div className="connection-item-details">
+									<div className="connection-item-name">${conn.name}</div>
+									<div className="connection-item-type">
+										${conn.api === API_LLAMA_CPP ? "llama.cpp" :
+  conn.api === API_KOBOLD_CPP ? "KoboldCpp" :
+  conn.api === API_AI_HORDE ? "AI Horde" :
+  conn.api === API_DEEPSEEK ? "DeepSeek" : "OpenAI"}
+									</div>
+								</div>
+							</div>
+						`)}
+					</div>
+				</div>
+
+				<div className="connection-details">
+					${currentConn ? html`
+						<div className="connection-header">
+							<div className="connection-header-title">
+								<div className="connection-back-btn" onClick=${() => setMobileShowDetails(false)}>
+									${iconBack}
+								</div>
+								${currentConn.name}
+							</div>
+							<div className="connection-actions">
+								<div className="connection-action-btn"
+									style=${isActiveConnection ? { opacity: '0.5', cursor: 'not-allowed' } : {}}
+									title=${isActiveConnection ? "Cannot disable the currently active connection" : "Toggle status"}
+									onClick=${() => {
+										if (isActiveConnection) return;
+										handleUpdateConnection(selectedId, 'enabled', !currentConn.enabled);
+									}}>
+									${currentConn.enabled ? html`<${SVG_CheckOn}/>` : html`<${SVG_CheckOff}/>`}
+									<span style=${{fontSize:'0.9em'}}>
+										${currentConn.enabled ? "Enabled" : "Disabled"}
+									</span>
+								</div>
+
+								<button className="connection-action-btn" onClick=${() => handleCloneConnection(selectedId)} title="Clone">
+									<svg width="1em" height="1em" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="9" y="9" width="13" height="13" rx="2" ry="2"></rect><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"></path></svg> Clone
+								</button>
+
+								<button className="connection-action-btn"
+									style=${isActiveConnection ? { opacity: '0.5', cursor: 'not-allowed' } : {}}
+									title=${isActiveConnection ? "Cannot delete the currently active connection" : "Delete"}
+									onClick=${() => handleDeleteConnection(selectedId)}>
+									<${SVG_Trash}/> Delete
+								</button>
+							</div>
+						</div>
+
+						<div style=${{padding: "12px 16px 0 16px"}}>
+							<${SelectBox}
+								label="API Type"
+								value=${currentConn.api}
+								onValueChange=${updateCurrentConnectionType}
+options=${[
+	{ name: 'OpenAI Compatible', value: API_OPENAI_COMPAT },
+	{ name: 'KoboldCpp', value: API_KOBOLD_CPP },
+	{ name: 'llama.cpp', value: API_LLAMA_CPP },
+	{ name: 'AI Horde', value: API_AI_HORDE },
+	{ name: 'DeepSeek', value: API_DEEPSEEK },
+]}/>
+						</div>
+
+						${currentConn.api === API_AI_HORDE
+							? html`<${AIHordeConnectionSettings}
+									key=${currentConn.id}
+									connection=${currentConn}
+									updateConnection=${updateCurrentConnection}
+								/>`
+							: html`<${GenericConnectionSettings}
+									key=${currentConn.id}
+									connection=${currentConn}
+									updateConnection=${updateCurrentConnection}
+								/>`
+						}
+					` : html`
+						<div className="connection-models-empty">
+							Select a connection to edit or create a new one.
+						</div>
+					`}
+				</div>
+			</div>
+		</${Modal}>
+	`;
+}

--- a/src/components/modals/SessionsModal.js
+++ b/src/components/modals/SessionsModal.js
@@ -207,6 +207,10 @@ export function SessionsModal({ isOpen, closeModal, sessionStorage, cancel }) {
 
 	const exportSession = () => {
 		const sessionObj = { ...sessionStorage.sessions[sessionStorage.selectedSession] };
+
+		delete sessionObj.endpoint;
+		delete sessionObj.endpointAPIKey;
+
 		for (const [key, value] of Object.entries(sessionObj)) {
 			sessionObj[key] = JSON.stringify(value);
 		}
@@ -219,6 +223,8 @@ export function SessionsModal({ isOpen, closeModal, sessionStorage, cancel }) {
 			const sessionKeys = Object.keys(sessionStorage.sessions);
 			for (const sessionKey of sessionKeys) {
 				const processedSession = await sessionStorage.loadFromDatabase(db, sessionKey);
+				delete processedSession.endpoint;
+				delete processedSession.endpointAPIKey;
 				for (const [key, value] of Object.entries(processedSession)) {
 					processedSession[key] = JSON.stringify(value);
 				}

--- a/src/components/modals/index.js
+++ b/src/components/modals/index.js
@@ -11,3 +11,4 @@ export { InstructModal } from './InstructModal.js';
 export { ThemeManagerModal } from './ThemeManagerModal.js';
 export { AIHordeSettingsModal } from './AIHordeSettingsModal.js';
 export { CompressionInfoModal } from './CompressionInfoModal.js';
+export { ConnectionManagerModal } from './ConnectionManagerModal.js';

--- a/src/contexts/SettingsContext.js
+++ b/src/contexts/SettingsContext.js
@@ -6,7 +6,7 @@ import { defaultThemes } from '../defaults/themes.js';
 
 export const SettingsContext = createContext(null);
 
-export function SettingsProvider({ children, sessionStorage, templateStorage, themeStorage, useSessionState, useDBTemplates, useDBThemes, isMiyapadEndpoint }) {
+export function SettingsProvider({ children, sessionStorage, templateStorage, themeStorage, connectionStorage, useSessionState, useDBTemplates, useDBThemes, useDBConnections, isMiyapadEndpoint }) {
 	const [templates, setTemplates] = useDBTemplates(defaultPresets.instructTemplates);
 	const [templateReplacements, setTemplateReplacements] = useState(false);
 	const [templatesImport, setTemplatesImport] = useState(false);
@@ -111,10 +111,12 @@ export function SettingsProvider({ children, sessionStorage, templateStorage, th
 	const [ttsSpeakInputs, setTTSSpeakInputs] = usePersistentState('ttsSpeakInputs', true);
 	const [ttsMaxUserInput, setTTSMaxUserInput] = usePersistentState('ttsMaxUserInput', 50);
 
+	const [connections, setConnections] = useDBConnections({});
+	const [selectedConnectionId, setSelectedConnectionId] = useSessionState('connectionId', 'custom');
 	const [useServerTokenization, setUseServerTokenization] = usePersistentState('useServerTokenization', false);
-const [tokenizerModel, setTokenizerModel] = usePersistentState('tokenizerModel', null);
+	const [tokenizerModel, setTokenizerModel] = usePersistentState('tokenizerModel', null);
 
-const [screenshotIncludeSessionName, setScreenshotIncludeSessionName] = usePersistentState('screenshotIncludeSessionName', true);
+	const [screenshotIncludeSessionName, setScreenshotIncludeSessionName] = usePersistentState('screenshotIncludeSessionName', true);
 	const [screenshotIncludeDate, setScreenshotIncludeDate] = usePersistentState('screenshotIncludeDate', true);
 	const [screenshotBackgroundUrl, setScreenshotBackgroundUrl] = usePersistentState('screenshotBackgroundUrl', '');
 	const [screenshotBackgroundColor, setScreenshotBackgroundColor] = usePersistentState('screenshotBackgroundColor', '#121212');
@@ -128,7 +130,8 @@ const [screenshotIncludeSessionName, setScreenshotIncludeSessionName] = usePersi
 	const [screenshotModelAvatarUrl, setScreenshotModelAvatarUrl] = usePersistentState('screenshotModelAvatarUrl', '');
 
 	const state = {
-		sessionStorage, templateStorage, themeStorage, useSessionState, useDBTemplates, useDBThemes, isMiyapadEndpoint,
+		sessionStorage, templateStorage, themeStorage, connectionStorage, useSessionState, useDBTemplates, useDBThemes, useDBConnections, isMiyapadEndpoint,
+		connections, setConnections, selectedConnectionId, setSelectedConnectionId,
 		templates, setTemplates, templateReplacements, setTemplateReplacements, templatesImport, setTemplatesImport,
 		selectedTemplate, setSelectedTemplate, chatMode, setChatMode, templateList, setTemplateList,
 		fontSizeMultiplier, setFontSizeMultiplier, spellCheck, setSpellCheck, attachSidebar, setAttachSidebar,

--- a/src/css/_connections.css
+++ b/src/css/_connections.css
@@ -226,7 +226,7 @@
 	font-size: 0.85em;
 	margin-bottom: 8px;
 	white-space: pre-wrap;
-	word-break: break-word;
+	overflow-wrap: break-word;
 	border: 1px solid var(--color-error);
 }
 

--- a/src/css/_connections.css
+++ b/src/css/_connections.css
@@ -1,0 +1,276 @@
+/* Connection Manager */
+.connection-modal-layout {
+	display: grid;
+	grid-template-columns: 240px 1fr;
+	gap: 0;
+	height: 60vh;
+	min-height: 450px;
+	border: 1px solid var(--color-bg-rule);
+	border-radius: 4px;
+	overflow: hidden;
+	background-color: var(--color-bg-ui-1);
+}
+
+.connection-sidebar {
+	background: var(--color-bg-ui-2);
+	border-right: 1px solid var(--color-bg-rule);
+	display: flex;
+	flex-direction: column;
+	overflow: hidden;
+}
+
+.connection-sidebar-header {
+	padding: 11px;
+	border-bottom: 1px solid var(--color-bg-rule);
+	display: flex;
+	justify-content: space-between;
+	align-items: center;
+	font-weight: bold;
+}
+
+.connection-list {
+	flex: 1;
+	overflow-y: auto;
+	min-height: 0;
+	padding: 8px;
+	display: flex;
+	flex-direction: column;
+	gap: 4px;
+}
+
+.connection-item {
+	padding: 7.5px 12px;
+	cursor: pointer;
+	display: flex;
+	align-items: center;
+	gap: 10px;
+	user-select: none;
+	border: 1px solid transparent;
+	color: var(--color-text-ui);
+	opacity: 0.5;
+}
+.connection-item.enabled {
+	opacity: 1;
+}
+
+.connection-item:hover {
+	background-color: var(--color-bg-highlight-3);
+}
+
+.connection-item.selected {
+	background-color: var(--color-bg-active);
+	border-color: var(--color-bg-highlight-1);
+	color: var(--color-text-ui);
+}
+
+.connection-item-icon {
+	display: grid;
+	place-items: center;
+	width: 20px;
+}
+
+.connection-item-details {
+	display: flex;
+	flex-direction: column;
+	overflow: hidden;
+}
+
+.connection-item-name {
+	font-weight: bold;
+	font-size: 0.95em;
+	white-space: nowrap;
+	overflow: hidden;
+	text-overflow: ellipsis;
+}
+
+.connection-item-type {
+	font-size: 0.75em;
+	opacity: 0.7;
+}
+
+.connection-details {
+	padding: 0;
+	overflow-y: hidden;
+	display: flex;
+	flex-direction: column;
+}
+
+.connection-header {
+	padding: 12px 16px;
+	border-bottom: 1px solid var(--color-bg-rule);
+	background-color: var(--color-bg-ui-1);
+	display: flex;
+	justify-content: space-between;
+	align-items: center;
+	flex-shrink: 0;
+}
+
+.connection-header-title {
+	font-size: 1.1em;
+	font-weight: bold;
+	display: flex;
+	align-items: center;
+	gap: 8px;
+}
+
+.connection-actions {
+	display: flex;
+	gap: 8px;
+	align-items: center;
+}
+
+.connection-action-btn {
+	background: transparent;
+	border: none;
+	cursor: pointer;
+	display: flex;
+	align-items: center;
+	gap: 6px;
+	font-size: 0.9em;
+	color: var(--color-text-ui);
+	padding: 4px 8px;
+	border-radius: 4px;
+	user-select: none;
+}
+.connection-action-btn:hover {
+	background-color: var(--color-bg-highlight-1);
+}
+
+.connection-content-scroll {
+	padding: 16px;
+	overflow-y: auto;
+	flex: 1;
+	display: flex;
+	flex-direction: column;
+	gap: 8px;
+}
+
+.connection-models-wrapper {
+	display: flex;
+	flex-direction: column;
+	flex: 1;
+	min-height: 0;
+}
+
+.connection-models-header {
+	display: flex;
+	align-items: center;
+	font-size: 0.75rem;
+	margin-bottom: 4px;
+	gap: 8px;
+}
+
+.connection-models-section {
+	border: 1px solid var(--color-bg-rule);
+	border-radius: 4px;
+	padding: 8px;
+	flex: 1;
+	min-height: 100px;
+	overflow-y: auto;
+	background: var(--color-bg-input-2);
+	font-family: monospace;
+	font-size: 0.85em;
+	display: flex;
+	flex-wrap: wrap;
+	align-content: flex-start;
+}
+
+.connection-models-empty {
+	width: 100%;
+	height: 100%;
+	display: grid;
+	place-items: center;
+	color: var(--color-text-hint);
+}
+
+.connection-model-list {
+	border: 1px solid var(--color-bg-rule);
+	border-radius: 4px;
+	flex: 1;
+	min-height: 150px;
+	overflow-y: auto;
+	background: var(--color-bg-input-2);
+	display: flex;
+	flex-direction: column;
+}
+
+.connection-model-item {
+	padding: 6px 10px;
+	cursor: pointer;
+	border-bottom: 1px solid var(--color-bg-rule);
+	font-size: 0.9em;
+	display: flex;
+	justify-content: space-between;
+	align-items: center;
+}
+
+.connection-model-item:last-child {
+	border-bottom: none;
+}
+
+.connection-model-item:hover {
+	background-color: var(--color-bg-highlight-3);
+}
+
+.connection-model-item.selected {
+	background-color: var(--color-bg-highlight-1);
+	color: var(--color-text-ui);
+	font-weight: bold;
+}
+
+.connection-error-msg {
+	color: var(--color-error);
+	background: var(--color-error-bg);
+	padding: 8px;
+	border-radius: 4px;
+	font-size: 0.85em;
+	margin-bottom: 8px;
+	white-space: pre-wrap;
+	word-break: break-word;
+	border: 1px solid var(--color-error);
+}
+
+.model-search-box {
+	margin-bottom: 8px;
+}
+
+.connection-back-btn {
+	display: none;
+	cursor: pointer;
+	margin-right: 12px;
+	padding: 4px;
+	border-radius: 4px;
+}
+.connection-back-btn:hover {
+	background-color: var(--color-bg-highlight-1);
+}
+
+@media (max-width: 767px) {
+	.connection-modal-layout {
+		display: block;
+		position: relative;
+	}
+
+	.connection-sidebar, .connection-details {
+		width: 100%;
+		height: 100%;
+		border-right: none;
+	}
+
+	.connection-modal-layout:not(.mobile-show-details) .connection-details {
+		display: none;
+	}
+
+	.connection-modal-layout.mobile-show-details .connection-sidebar {
+		display: none;
+	}
+
+	.connection-back-btn {
+		display: flex;
+		align-items: center;
+	}
+
+	.connection-header {
+		padding: 8px 12px;
+	}
+}

--- a/src/css/_variables.css
+++ b/src/css/_variables.css
@@ -40,6 +40,8 @@ html {
 	--color-bg-active: var(--color-base-30);
 	--color-bg-disabled-1: var(--color-base-60);
 	--color-bg-disabled-2: var(--color-base-20);
+	--color-error: #ff8080;
+	--color-error-bg: #4E3534;
 
 	font-family: serif;
 	font-size: 16px;

--- a/src/main.js
+++ b/src/main.js
@@ -8,6 +8,7 @@ import { ServerDBAdapter } from './storage/ServerDBAdapter.js';
 import { SessionStorage } from './storage/SessionStorage.js';
 import { TemplateStorage } from './storage/TemplateStorage.js';
 import { ThemeStorage } from './storage/ThemeStorage.js';
+import { ConnectionStorage } from './storage/ConnectionStorage.js';
 import { useSessionState } from './hooks/useSessionState.js';
 import { useStorageState } from './hooks/useStorageState.js';
 import { CrashScreenFallback } from './components/CrashScreenFallback.js';
@@ -42,15 +43,20 @@ async function main() {
     const themeStorage = new ThemeStorage(dbAdapter);
     await themeStorage.init();
 
+    const connectionStorage = new ConnectionStorage(dbAdapter);
+    await connectionStorage.init();
+
 	createRoot(document.body).render(html`
 		<${ErrorBoundary} FallbackComponent=${CrashScreenFallback}>
 			<${App}
 				sessionStorage=${sessionStorage}
 				templateStorage=${templateStorage}
 				themeStorage=${themeStorage}
+				connectionStorage=${connectionStorage}
 				useSessionState=${(name, initialState) => useSessionState(sessionStorage, name, initialState)}
 				useDBTemplates=${(initialState => useStorageState(templateStorage, initialState))}
 				useDBThemes=${(initialState => useStorageState(themeStorage, initialState))}
+				useDBConnections=${(initialState => useStorageState(connectionStorage, initialState))}
 				isMiyapadEndpoint=${isMiyapadEndpoint}/>
 		</${ErrorBoundary}>`);
 }

--- a/src/storage/ConnectionStorage.js
+++ b/src/storage/ConnectionStorage.js
@@ -12,22 +12,26 @@ export class ConnectionStorage extends AbstractStorage {
 	}
 
 	async performFullSave(newConnections) {
-		const db = await this.openDatabase();
+		try {
+			const db = await this.openDatabase();
 
-		for (const key of Object.keys(this.connections)) {
-			if (!newConnections.hasOwnProperty(key)) {
-				await this.deleteFromDatabase(db, key);
+			for (const key of Object.keys(this.connections)) {
+				if (!newConnections.hasOwnProperty(key)) {
+					await this.deleteFromDatabase(db, key);
+				}
 			}
-		}
 
-		for (const [key, value] of Object.entries(newConnections)) {
-			if (JSON.stringify(value) !== JSON.stringify(this.connections[key])) {
-				await this.saveToDatabase(db, key, value);
+			for (const [key, value] of Object.entries(newConnections)) {
+				if (JSON.stringify(value) !== JSON.stringify(this.connections[key])) {
+					await this.saveToDatabase(db, key, value);
+				}
 			}
-		}
 
-		this.connections = newConnections;
-		this.dispatchChangeEvent();
+			this.connections = newConnections;
+			this.dispatchChangeEvent();
+		} catch (error) {
+			this.dispatchErrorEvent(error);
+		}
 	}
 
 	getStorageData() {

--- a/src/storage/ConnectionStorage.js
+++ b/src/storage/ConnectionStorage.js
@@ -1,0 +1,40 @@
+import { AbstractStorage } from './AbstractStorage.js';
+
+export class ConnectionStorage extends AbstractStorage {
+	constructor(dbAdapter) {
+		super('Connections', dbAdapter);
+		this.connections = {};
+	}
+
+	async init() {
+		const db = await this.openDatabase();
+		await this.loadConnections(db);
+	}
+
+	async performFullSave(newConnections) {
+		const db = await this.openDatabase();
+
+		for (const key of Object.keys(this.connections)) {
+			if (!newConnections.hasOwnProperty(key)) {
+				await this.deleteFromDatabase(db, key);
+			}
+		}
+
+		for (const [key, value] of Object.entries(newConnections)) {
+			if (JSON.stringify(value) !== JSON.stringify(this.connections[key])) {
+				await this.saveToDatabase(db, key, value);
+			}
+		}
+
+		this.connections = newConnections;
+		this.dispatchChangeEvent();
+	}
+
+	getStorageData() {
+		return this.connections;
+	}
+
+	async loadConnections(db) {
+		this.connections = await this.loadAllFromDatabase(db);
+	}
+}

--- a/src/storage/ConnectionStorage.js
+++ b/src/storage/ConnectionStorage.js
@@ -16,7 +16,7 @@ export class ConnectionStorage extends AbstractStorage {
 			const db = await this.openDatabase();
 
 			for (const key of Object.keys(this.connections)) {
-				if (!newConnections.hasOwnProperty(key)) {
+				if (!Object.hasOwn(newConnections, key)) {
 					await this.deleteFromDatabase(db, key);
 				}
 			}

--- a/src/storage/IndexedDBAdapter.js
+++ b/src/storage/IndexedDBAdapter.js
@@ -26,7 +26,7 @@ export class IndexedDBAdapter {
 
 	async openDatabase() {
 		return new Promise((resolve, reject) => {
-			const openRequest = indexedDB.open(this.dbName, 4);
+			const openRequest = indexedDB.open(this.dbName, 5);
 
 			openRequest.onerror = () => reject(openRequest.error);
 			openRequest.onsuccess = () => resolve(openRequest.result);
@@ -35,7 +35,7 @@ export class IndexedDBAdapter {
 				const db = event.target.result;
 				const transaction = event.target.transaction;
 
-				for (const storeName of ["Sessions", "Templates", "Names", "Themes"]) {
+				for (const storeName of ["Sessions", "Templates", "Names", "Themes", "Connections"]) {
 					if (!db.objectStoreNames.contains(storeName)) {
 						db.createObjectStore(storeName);
 					}

--- a/src/styles.css
+++ b/src/styles.css
@@ -16,4 +16,5 @@
 @import './css/_crash-screen.css';
 @import './css/_utilities.css';
 @import './css/_quick-switcher.css';
+@import './css/_connections.css';
 @import './css/_responsive.css';


### PR DESCRIPTION
## Summary

Cherry-pick **Connection Manager** PR from [upstream](https://github.com/lmg-anon/mikupad/pull/134) — saved connection presets (endpoint, API type, model, key) that persist in IndexedDB / SQLite and can be selected per-session from the sidebar.

## Changes

### New Files
- `src/components/modals/ConnectionManagerModal.js` — Full modal UI for CRUD on connection presets with model browser and API-specific settings
- `src/storage/ConnectionStorage.js` — Storage adapter following `AbstractStorage` pattern
- `src/css/_connections.css` — CSS partial for the connection manager UI

### Modified Files
- `src/components/Sidebar.js` — Connection preset selector + apply logic, session-switch re-application
- `src/components/Modals.js` — Registers ConnectionManagerModal
- `src/contexts/SettingsContext.js` — Wires connections state + per-session `connectionId`
- `src/storage/IndexedDBAdapter.js` — Bumps DB to v5, adds Connections store
- `server/lib/database.js` — Server-side connections table
- `server/lib/utils.js` — Adds `connections` to allowed stores
- `src/components/icons/index.js` — SVG_CheckOn/SVG_CheckOff icons
- `src/components/modals/SessionsModal.js` — Credential stripping on exportAll
- `src/components/Modal.js` — Improved overlay click-to-close
- `src/components/modals/index.js` — Barrel export
- `src/App.js`, `src/main.js`, `src/styles.css` — Wires up connection storage

### Bug Fixes Included
- `exportAll` now strips `endpoint`/`endpointAPIKey` (credential leak)
- AbortControllers abort on unmount via useRef + useEffect
- Connection settings re-applied when switching sessions
- Merged redundant useLayoutEffect blocks; removed unused `cancel` prop
- Hardcoded CSS error colors replaced with CSS vars

## Documentation
- CHANGELOG, README, architecture, backend-server, CSS docs all updated

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Connection Manager modal: save, clone, edit, enable/disable, and switch named connection presets with model browsing and API-specific options (including AI Horde multi-model support).
  * Per-session connection binding and persistent connection storage across backends.

* **Bug Fixes**
  * Modal backdrop now requires deliberate mouse-down before click to avoid accidental dismissal.
  * Modal tooltips no longer get clipped.

* **Changed**
  * Session exports now omit endpoint and API key fields.
  * CSS and docs updated to include Connection Manager UI.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->