### PR TITLE
Bundle sqlite-zstd extension in distribution

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,6 +26,7 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:
           persist-credentials: false
+          submodules: true
 
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
@@ -38,6 +39,25 @@ jobs:
       - name: Install server deps
         working-directory: server
         run: npm ci
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: stable
+
+      - name: Build sqlite-zstd
+        working-directory: server/sqlite-zstd
+        run: cargo build --release --features build_extension
+
+      - name: Copy sqlite-zstd extension
+        working-directory: server
+        shell: bash
+        run: |
+          case "${{ matrix.platform }}" in
+            linux) cp sqlite-zstd/target/release/libsqlite_zstd.so . ;;
+            macos) cp sqlite-zstd/target/release/libsqlite_zstd.dylib . ;;
+            win)   cp sqlite-zstd/target/release/sqlite_zstd.dll . ;;
+          esac
 
       - name: Bundle server
         working-directory: server

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,7 +41,7 @@ jobs:
         run: npm ci
 
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@4be7066ada62dd38de10e7b70166bc74ed198c30
         with:
           toolchain: stable
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,6 +45,10 @@ jobs:
         with:
           toolchain: stable
 
+      - uses: Swatinem/rust-cache@42dc69e1aa15d09112580998cf2ef0119e2e91ae
+        with:
+          workspaces: server/sqlite-zstd
+
       - name: Build sqlite-zstd
         working-directory: server/sqlite-zstd
         run: cargo build --release --features build_extension
@@ -52,8 +56,10 @@ jobs:
       - name: Copy sqlite-zstd extension
         working-directory: server
         shell: bash
+        env:
+          PLATFORM: ${{ matrix.platform }}
         run: |
-          case "${{ matrix.platform }}" in
+          case "$PLATFORM" in
             linux) cp sqlite-zstd/target/release/libsqlite_zstd.so . ;;
             macos) cp sqlite-zstd/target/release/libsqlite_zstd.dylib . ;;
             win)   cp sqlite-zstd/target/release/sqlite_zstd.dll . ;;

--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,6 @@ server/*.exe
 server/backups/
 server/dist-server/
 server/miyapad-dist/
+
+# Opencode config
+.opencode/

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "server/sqlite-zstd"]
+	path = server/sqlite-zstd
+	url = https://github.com/phiresky/sqlite-zstd.git

--- a/server/THIRD_PARTY_LICENSES
+++ b/server/THIRD_PARTY_LICENSES
@@ -35,3 +35,7 @@ Axios — MIT
 Socket.IO — MIT
   Copyright (c) 2014-present Guillermo Rauch and contributors
   https://github.com/socketio/socket.io/blob/main/LICENSE
+
+sqlite-zstd — LGPL-3.0
+  Copyright (c) 2022 phiresky
+  https://github.com/phiresky/sqlite-zstd/blob/master/LICENSE

--- a/server/THIRD_PARTY_LICENSES
+++ b/server/THIRD_PARTY_LICENSES
@@ -39,3 +39,6 @@ Socket.IO — MIT
 sqlite-zstd — LGPL-3.0
   Copyright (c) 2022 phiresky
   https://github.com/phiresky/sqlite-zstd/blob/master/LICENSE
+  Note: Cargo.toml metadata declares LGPL-2.0-or-later; the LICENSE file
+  bundled in the repository is LGPL-3.0. Pending upstream clarification,
+  we treat this as LGPL-3.0.

--- a/server/scripts/pack-dist.mjs
+++ b/server/scripts/pack-dist.mjs
@@ -9,7 +9,6 @@ const distDir = path.join(root, 'miyapad-dist');
 fs.rmSync(distDir, { recursive: true, force: true });
 fs.mkdirSync(distDir, { recursive: true });
 
-// sqlite-zstd is user-provided for now; will be built and bundled later
 const nodeDest = process.platform === 'win32' ? 'node.exe' : 'node';
 fs.copyFileSync(process.execPath, path.join(distDir, nodeDest));
 
@@ -17,6 +16,15 @@ fs.copyFileSync(
   path.join(root, 'dist-server', 'server.cjs'),
   path.join(distDir, 'server.cjs')
 );
+
+const zstdLibName = process.platform === 'win32' ? 'sqlite_zstd.dll'
+  : `libsqlite_zstd.${process.platform === 'darwin' ? 'dylib' : 'so'}`;
+const zstdSrc = path.join(root, zstdLibName);
+if (fs.existsSync(zstdSrc)) {
+  fs.copyFileSync(zstdSrc, path.join(distDir, zstdLibName));
+} else {
+  console.warn(`Warning: ${zstdLibName} not found, skipping`);
+}
 
 const copyDir = (src, dest) => {
   if (!fs.existsSync(src)) return;
@@ -34,25 +42,11 @@ fs.copyFileSync(path.join(root, 'THIRD_PARTY_LICENSES'), path.join(distDir, 'THI
 fs.writeFileSync(path.join(distDir, 'miyapad.sh'), `#!/bin/sh
 set -e
 DIR="\$(CDPATH='' cd -- "\$(dirname -- "\$0")" && pwd -P)"
-ZSTD="libsqlite_zstd.so"
-[ "\$(uname -s)" = "Darwin" ] && ZSTD="libsqlite_zstd.dylib"
-if [ ! -f "\$DIR/\$ZSTD" ]; then
-  echo "Error: \$ZSTD not found in \$DIR" >&2
-  echo "Download the sqlite-zstd extension for your platform from:" >&2
-  echo "  https://github.com/phiresky/sqlite-zstd" >&2
-  exit 1
-fi
 exec "\$DIR/node" "\$DIR/server.cjs" "\$@"
 `, { mode: 0o755 });
 
 fs.writeFileSync(path.join(distDir, 'miyapad.bat'), `@echo off
 set "DIR=%~dp0"
-set "ZSTD=%DIR%sqlite_zstd.dll"
-if not exist "%ZSTD%" (
-  echo Error: sqlite_zstd.dll not found
-  echo Download from https://github.com/phiresky/sqlite-zstd
-  exit /b 1
-)
 "%DIR%node.exe" "%DIR%server.cjs" %*
 `);
 

--- a/server/scripts/pack-dist.mjs
+++ b/server/scripts/pack-dist.mjs
@@ -23,7 +23,8 @@ const zstdSrc = path.join(root, zstdLibName);
 if (fs.existsSync(zstdSrc)) {
   fs.copyFileSync(zstdSrc, path.join(distDir, zstdLibName));
 } else {
-  console.warn(`Warning: ${zstdLibName} not found, skipping`);
+  console.error(`Error: ${zstdLibName} not found`);
+  process.exit(1);
 }
 
 const copyDir = (src, dest) => {


### PR DESCRIPTION
**What**: Build the `sqlite-zstd` SQLite extension from source (Rust) in CI and bundle it with the server distribution, removing the manual user-download step.

**Why**: Previously, users had to download `libsqlite_zstd.so`/`.dylib`/`.dll` from the sqlite-zstd GitHub repo and place it next to the server binary, or the launcher script would exit with an error.

**Changes**:
- Add `sqlite-zstd` as a git submodule (`server/sqlite-zstd`)
- CI workflow: install Rust, `cargo build --release`, copy the platform-appropriate extension into the server directory before bundling
- `pack-dist.mjs`: copy the built extension into the dist folder alongside `node` and `server.cjs`
- Drop the `if [ ! -f ... ]` guard + error messages from `miyapad.sh` and `miyapad.bat` — the extension is now always present
- Add LGPL-3.0 license entry for sqlite-zstd

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved release builds to automatically bundle the required SQLite compression extension for Linux, macOS, and Windows.
  * Updated distribution packaging and launchers to directly start without extra runtime/platform checks.

* **Bug Fixes**
  * Release packaging now fails fast with a clear error if the bundled extension is missing.

* **Chores**
  * Added third-party license attribution for the bundled component.
  * Updated git ignore rules for local configuration and added the submodule reference.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->