### PR TITLE
feat(updater): add version display and update check

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,9 @@ node_modules/
 dist/
 .parcel-cache/
 
+# Generated version file
+src/version.ts
+
 # Databases (SQLite)
 *.db
 *.db-journal

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [???] - unreleased
+
+### Added
+- About dialog showing the current version, with a "Check for Updates" button that reports the latest release and links to the download
+- Bundled `miyapad-update.sh` / `miyapad-update.ps1` scripts in server distributions for one-command updates
+
 ## [2.5.3] - 2026-07-03
 
 ### Fixed

--- a/docs/api-endpoints.md
+++ b/docs/api-endpoints.md
@@ -2,7 +2,7 @@
 
 | Route | Method | Description |
 | :--- | :--- | :--- |
-| `/version` | GET | Returns backend API version (`4`) and features. |
+| `/version` | GET | Returns backend API version (`4`), features, available tokenizers, and update info (`latestVersion`, `downloadUrl`) from a cached GitHub latest-release check. |
 | `/vacuum` | GET | Runs a full SQLite `VACUUM` to compact database storage. |
 | `/zstd_maintenance` | POST | Runs `SELECT zstd_incremental_maintenance(duration, db_load)` with optional `duration` (sec, ≥0 or null) and `dbLoad` (0.0–1.0) from body. Validates both before passing to SQLite. Manually triggers zstd dictionary maintenance. |
 | `/maintenance_config` | GET | Returns the current scheduler/WAL configuration `{ duration, dbLoad, mode, interval, walEnabled }`. |

--- a/docs/building-and-running.md
+++ b/docs/building-and-running.md
@@ -9,6 +9,8 @@ From the root directory:
 3. Build for production: `npm run build` (Runs `parcel build miyapad.html --no-cache`)
 4. Type-check the frontend: `tsc --noEmit` (validates types without emitting files — Parcel handles transpilation independently)
 
+The `prebuild` and `prestart` hooks run `scripts/write-version.mjs`, which reads the root `package.json` version and writes `src/version.ts` (gitignored) exporting `APP_VERSION`.
+
 ## Backend Server
 
 From the `server/` directory:
@@ -33,6 +35,7 @@ The resulting `miyapad-dist/` folder is the redistributable:
 ```text
 miyapad-dist/
   miyapad.sh / miyapad.bat  # Launch scripts
+  miyapad-update.sh / .ps1  # In-place update scripts (download + extract latest release)
   node / node.exe           # Node.js binary (from actions/setup-node)
   server.cjs                # esbuild server bundle
   libsqlite_zstd.*          # sqlite-zstd SQLite extension (bundled)

--- a/docs/project-structure.md
+++ b/docs/project-structure.md
@@ -6,6 +6,8 @@ miyapad/
 │   ├── release.yml                # Build & attach to GitHub Release on v* tags
 │   └── pages.yml                  # Deploy to GitHub Pages on v* tags
 ├── dist/                          # Frontend production build output
+├── scripts/                       # Root build scripts
+│   └── write-version.mjs          # Generates src/version.ts from package.json (prebuild/prestart)
 ├── server/dist-server/            # esbuild server bundle output (generated)
 ├── server/miyapad-dist/           # Standalone distribution folder (generated)
 ├── miyapad.html                   # HTML entry point (loads src/main.tsx as module)
@@ -17,6 +19,7 @@ miyapad/
 │   │   ├── auth.ts                # Basic Auth middleware factory
 │   │   ├── backup.ts              # Auto-backup with VACUUM INTO, data_version check, rotation
 │   │   ├── database.ts            # DB connection, migrations, zstd setup, maintenance
+│   │   ├── update.ts              # Cached GitHub latest-release check for the update feature
 │   │   └── utils.ts               # Helpers (column names, compression, header filters)
 │   ├── routes/                    # Express route handlers by concern
 │   │   ├── data.ts                # /load, /save, /rename, /all, /sessions, /delete
@@ -25,7 +28,9 @@ miyapad/
 │   │   ├── tokenizer.ts           # /api/v1/tokenizer/* endpoints
 │   │   └── zstd.ts                # /zstd_* management endpoints
 │   ├── scripts/                   # Build scripts
-│   │   └── pack-dist.mjs          # Assembles miyapad-dist/ with node binary, bundle, deps, launch scripts
+│   │   ├── pack-dist.mjs          # Assembles miyapad-dist/ with node binary, bundle, deps, launch + update scripts
+│   │   ├── miyapad-update.sh      # POSIX in-place updater (Linux/macOS)
+│   │   └── miyapad-update.ps1     # PowerShell in-place updater (Windows)
 │   ├── server.ts                  # Entrypoint: arg parsing, app setup, mount routes, start
 │   ├── tokenizer.ts               # Server-side tokenization (HuggingFace tokenizers)
 │   ├── types/                     # Ambient type declarations for the server
@@ -41,6 +46,7 @@ miyapad/
     ├── constants.ts               # Application-wide constants and enum definitions
     ├── main.tsx                   # Entry point; detects database adapter and renders
     ├── polyfills.ts               # Browser polyfills
+    ├── version.ts                 # Generated (gitignored) — exports APP_VERSION from package.json
     ├── worldinfo.ts               # World info / lorebook data structures
     ├── api/                       # API modules for backends (.ts)
     ├── components/                # React components (Modals, Sidebar, controls, icons — .tsx)

--- a/package.json
+++ b/package.json
@@ -1,10 +1,12 @@
 {
   "name": "miyapad",
+  "version": "2.5.3",
   "source": "miyapad.html",
   "scripts": {
+    "prestart": "node scripts/write-version.mjs",
     "start": "parcel",
     "clean": "rm -rf dist .parcel-cache",
-    "prebuild": "npm run clean",
+    "prebuild": "node scripts/write-version.mjs && npm run clean",
     "build": "parcel build miyapad.html --no-cache",
     "postbuild": "node scripts/inline-dist.mjs && rm -rf .parcel-cache",
     "build:dist": "npm run build && cd server && npm run build:dist",

--- a/scripts/write-version.mjs
+++ b/scripts/write-version.mjs
@@ -1,0 +1,10 @@
+import { readFileSync, writeFileSync } from 'fs';
+import { dirname, join } from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const root = join(__dirname, '..');
+const { version } = JSON.parse(readFileSync(join(root, 'package.json'), 'utf-8'));
+
+writeFileSync(join(root, 'src', 'version.ts'), `export const APP_VERSION = '${version}';\n`);
+console.log(`Wrote src/version.ts (v${version})`);

--- a/server/lib/update.ts
+++ b/server/lib/update.ts
@@ -29,7 +29,8 @@ export async function checkForUpdate(): Promise<UpdateInfo> {
         };
         cache = { at: Date.now(), ttl: TTL, info };
         return info;
-    } catch {
+    } catch (err) {
+        console.error('Update check failed:', (err as Error).message);
         const info: UpdateInfo = { latestVersion: null, downloadUrl: null };
         cache = { at: Date.now(), ttl: FAIL_TTL, info };
         return info;

--- a/server/lib/update.ts
+++ b/server/lib/update.ts
@@ -2,16 +2,17 @@ import axios from 'axios';
 
 const RELEASE_URL = 'https://api.github.com/repos/lordfoogthe4rd/miyapad/releases/latest';
 const TTL = 60 * 60 * 1000;
+const FAIL_TTL = 5 * 60 * 1000;
 
 interface UpdateInfo {
     latestVersion: string | null;
     downloadUrl: string | null;
 }
 
-let cache: { at: number; info: UpdateInfo } | null = null;
+let cache: { at: number; ttl: number; info: UpdateInfo } | null = null;
 
 export async function checkForUpdate(): Promise<UpdateInfo> {
-    if (cache && Date.now() - cache.at < TTL) {
+    if (cache && Date.now() - cache.at < cache.ttl) {
         return cache.info;
     }
     try {
@@ -23,9 +24,11 @@ export async function checkForUpdate(): Promise<UpdateInfo> {
             latestVersion: typeof data.tag_name === 'string' ? data.tag_name.replace(/^v/, '') : null,
             downloadUrl: typeof data.html_url === 'string' ? data.html_url : null
         };
-        cache = { at: Date.now(), info };
+        cache = { at: Date.now(), ttl: TTL, info };
         return info;
     } catch {
-        return { latestVersion: null, downloadUrl: null };
+        const info: UpdateInfo = { latestVersion: null, downloadUrl: null };
+        cache = { at: Date.now(), ttl: FAIL_TTL, info };
+        return info;
     }
 }

--- a/server/lib/update.ts
+++ b/server/lib/update.ts
@@ -1,5 +1,8 @@
 import axios from 'axios';
 
+// ponytail: repo slug also lives in src/hooks/useUpdateCheck.ts and the
+// miyapad-update scripts. Not shared config — spans 3 build contexts for a
+// value that never changes; centralize via build-time injection if it does.
 const RELEASE_URL = 'https://api.github.com/repos/lordfoogthe4rd/miyapad/releases/latest';
 const TTL = 60 * 60 * 1000;
 const FAIL_TTL = 5 * 60 * 1000;

--- a/server/lib/update.ts
+++ b/server/lib/update.ts
@@ -13,11 +13,11 @@ interface UpdateInfo {
 }
 
 let cache: { at: number; ttl: number; info: UpdateInfo } | null = null;
+let inflight: Promise<UpdateInfo> | null = null;
 
-export async function checkForUpdate(): Promise<UpdateInfo> {
-    if (cache && Date.now() - cache.at < cache.ttl) {
-        return cache.info;
-    }
+const EMPTY: UpdateInfo = { latestVersion: null, downloadUrl: null };
+
+async function fetchUpdate(): Promise<UpdateInfo> {
     try {
         const { data } = await axios.get(RELEASE_URL, {
             headers: { Accept: 'application/vnd.github+json' },
@@ -31,8 +31,27 @@ export async function checkForUpdate(): Promise<UpdateInfo> {
         return info;
     } catch (err) {
         console.error('Update check failed:', (err as Error).message);
-        const info: UpdateInfo = { latestVersion: null, downloadUrl: null };
-        cache = { at: Date.now(), ttl: FAIL_TTL, info };
-        return info;
+        cache = { at: Date.now(), ttl: FAIL_TTL, info: EMPTY };
+        return EMPTY;
+    } finally {
+        inflight = null;
     }
+}
+
+// Coalesced fetch: concurrent cache misses share a single GitHub request.
+export function checkForUpdate(): Promise<UpdateInfo> {
+    if (cache && Date.now() - cache.at < cache.ttl) {
+        return Promise.resolve(cache.info);
+    }
+    inflight ??= fetchUpdate();
+    return inflight;
+}
+
+// Non-blocking: returns cached/stale data immediately and refreshes in the
+// background. Keeps the /version hot path off the 10s GitHub round-trip.
+export function getUpdateInfo(): UpdateInfo {
+    if (!cache || Date.now() - cache.at >= cache.ttl) {
+        void checkForUpdate();
+    }
+    return cache?.info ?? EMPTY;
 }

--- a/server/lib/update.ts
+++ b/server/lib/update.ts
@@ -1,0 +1,31 @@
+import axios from 'axios';
+
+const RELEASE_URL = 'https://api.github.com/repos/lordfoogthe4rd/miyapad/releases/latest';
+const TTL = 60 * 60 * 1000;
+
+interface UpdateInfo {
+    latestVersion: string | null;
+    downloadUrl: string | null;
+}
+
+let cache: { at: number; info: UpdateInfo } | null = null;
+
+export async function checkForUpdate(): Promise<UpdateInfo> {
+    if (cache && Date.now() - cache.at < TTL) {
+        return cache.info;
+    }
+    try {
+        const { data } = await axios.get(RELEASE_URL, {
+            headers: { Accept: 'application/vnd.github+json' },
+            timeout: 10000
+        });
+        const info: UpdateInfo = {
+            latestVersion: typeof data.tag_name === 'string' ? data.tag_name.replace(/^v/, '') : null,
+            downloadUrl: typeof data.html_url === 'string' ? data.html_url : null
+        };
+        cache = { at: Date.now(), info };
+        return info;
+    } catch {
+        return { latestVersion: null, downloadUrl: null };
+    }
+}

--- a/server/routes/system.ts
+++ b/server/routes/system.ts
@@ -2,13 +2,13 @@ import type { Express, Request, Response } from 'express';
 import type { Database } from 'sqlite3';
 import * as tokenizer from '../tokenizer.js';
 import { runZstdMaintenance, configureWAL, getMaintenanceConfig, saveMaintenanceConfig, clearMaintenanceScheduler, scheduleZstdMaintenance } from '../lib/database.js';
-import { checkForUpdate } from '../lib/update.js';
+import { getUpdateInfo } from '../lib/update.js';
 
 const SERVER_VERSION = 4;
 
 export default function(app: Express, db: Database): void {
-    app.get('/version', async (req: Request, res: Response) => {
-        const update = await checkForUpdate();
+    app.get('/version', (req: Request, res: Response) => {
+        const update = getUpdateInfo();
         res.json({
             version: SERVER_VERSION,
             features: { zstd_compression: true, server_tokenizer: true },

--- a/server/routes/system.ts
+++ b/server/routes/system.ts
@@ -2,15 +2,19 @@ import type { Express, Request, Response } from 'express';
 import type { Database } from 'sqlite3';
 import * as tokenizer from '../tokenizer.js';
 import { runZstdMaintenance, configureWAL, getMaintenanceConfig, saveMaintenanceConfig, clearMaintenanceScheduler, scheduleZstdMaintenance } from '../lib/database.js';
+import { checkForUpdate } from '../lib/update.js';
 
 const SERVER_VERSION = 4;
 
 export default function(app: Express, db: Database): void {
-    app.get('/version', (req: Request, res: Response) => {
+    app.get('/version', async (req: Request, res: Response) => {
+        const update = await checkForUpdate();
         res.json({
             version: SERVER_VERSION,
             features: { zstd_compression: true, server_tokenizer: true },
-            tokenizers: tokenizer.getAvailableTokenizers()
+            tokenizers: tokenizer.getAvailableTokenizers(),
+            latestVersion: update.latestVersion,
+            downloadUrl: update.downloadUrl
         });
     });
 

--- a/server/scripts/miyapad-update.ps1
+++ b/server/scripts/miyapad-update.ps1
@@ -24,8 +24,18 @@ if (-not (Test-Path $archive) -or (Get-Item $archive).Length -eq 0) {
 }
 
 $dir = Split-Path -Parent $MyInvocation.MyCommand.Path
-Write-Host "Extracting into $dir"
-Expand-Archive -Path $archive -DestinationPath $dir -Force
-Remove-Item $archive -Force
+$stage = Join-Path $env:TEMP ("miyapad-stage-" + [System.Guid]::NewGuid().ToString('N'))
+# ponytail: extract to staging first so a bad/interrupted archive can't
+# half-overwrite the live install. Trusted GitHub source, no rollback.
+try {
+	Write-Host 'Staging update...'
+	Expand-Archive -Path $archive -DestinationPath $stage -Force
+	Write-Host "Installing into $dir"
+	Copy-Item -Path (Join-Path $stage '*') -Destination $dir -Recurse -Force
+}
+finally {
+	Remove-Item $archive -Force -ErrorAction SilentlyContinue
+	Remove-Item $stage -Recurse -Force -ErrorAction SilentlyContinue
+}
 
 Write-Host 'Update complete. Restart miyapad to apply.'

--- a/server/scripts/miyapad-update.ps1
+++ b/server/scripts/miyapad-update.ps1
@@ -1,0 +1,31 @@
+$ErrorActionPreference = 'Stop'
+
+$repo = 'lordfoogthe4rd/miyapad'
+$api = "https://api.github.com/repos/$repo/releases/latest"
+
+Write-Host 'Fetching latest release...'
+$release = Invoke-RestMethod -Uri $api -Headers @{ 'Accept' = 'application/vnd.github+json'; 'User-Agent' = 'miyapad-update' }
+
+$asset = $release.assets | Where-Object { $_.name -like '*win-x64*' } | Select-Object -First 1
+
+if (-not $asset) {
+	Write-Host "No matching asset found for win-x64."
+	Write-Host "Download manually from: $($release.html_url)"
+	exit 1
+}
+
+$archive = Join-Path $env:TEMP 'miyapad-update.zip'
+Write-Host "Downloading $($asset.browser_download_url)"
+Invoke-WebRequest -Uri $asset.browser_download_url -OutFile $archive
+
+if (-not (Test-Path $archive) -or (Get-Item $archive).Length -eq 0) {
+	Write-Host 'Downloaded file is empty. Aborting.'
+	exit 1
+}
+
+$dir = Split-Path -Parent $MyInvocation.MyCommand.Path
+Write-Host "Extracting into $dir"
+Expand-Archive -Path $archive -DestinationPath $dir -Force
+Remove-Item $archive -Force
+
+Write-Host 'Update complete. Restart miyapad to apply.'

--- a/server/scripts/miyapad-update.sh
+++ b/server/scripts/miyapad-update.sh
@@ -6,11 +6,13 @@ API="https://api.github.com/repos/$REPO/releases/latest"
 
 case "$(uname -s)" in
 	Darwin) OS="macos" ;;
-	*)      OS="linux" ;;
+	Linux)  OS="linux" ;;
+	*)      echo "Unsupported operating system." >&2; exit 1 ;;
 esac
 case "$(uname -m)" in
 	arm64|aarch64) ARCH="arm64" ;;
-	*)             ARCH="x64" ;;
+	x86_64|amd64)  ARCH="x64" ;;
+	*)             echo "Unsupported architecture." >&2; exit 1 ;;
 esac
 PLATFORM="$OS-$ARCH"
 
@@ -33,7 +35,8 @@ if [ -z "$ASSET_URL" ]; then
 	exit 1
 fi
 
-ARCHIVE="/tmp/miyapad-update.tar.gz"
+ARCHIVE="$(mktemp "${TMPDIR:-/tmp}/miyapad-update.XXXXXX")"
+trap 'rm -f "$ARCHIVE"' EXIT
 echo "Downloading $ASSET_URL"
 curl -fSL "$ASSET_URL" -o "$ARCHIVE"
 
@@ -45,6 +48,5 @@ fi
 DIR="$(CDPATH='' cd -- "$(dirname -- "$0")" && pwd -P)"
 echo "Extracting into $DIR"
 tar -xzf "$ARCHIVE" -C "$DIR"
-rm -f "$ARCHIVE"
 
 echo "Update complete. Restart miyapad to apply."

--- a/server/scripts/miyapad-update.sh
+++ b/server/scripts/miyapad-update.sh
@@ -1,0 +1,50 @@
+#!/bin/sh
+set -e
+
+REPO="lordfoogthe4rd/miyapad"
+API="https://api.github.com/repos/$REPO/releases/latest"
+
+case "$(uname -s)" in
+	Darwin) OS="macos" ;;
+	*)      OS="linux" ;;
+esac
+case "$(uname -m)" in
+	arm64|aarch64) ARCH="arm64" ;;
+	*)             ARCH="x64" ;;
+esac
+PLATFORM="$OS-$ARCH"
+
+echo "Detected platform: $PLATFORM"
+echo "Fetching latest release..."
+
+JSON="$(curl -fsSL -H 'Accept: application/vnd.github+json' "$API")"
+
+ASSET_URL="$(printf '%s\n' "$JSON" \
+	| grep '"browser_download_url"' \
+	| sed -E 's/.*"(https:[^"]+)".*/\1/' \
+	| grep "$PLATFORM" \
+	| head -n1)"
+
+RELEASE_URL="$(printf '%s\n' "$JSON" | grep '"html_url"' | head -n1 | sed -E 's/.*"(https:[^"]+)".*/\1/')"
+
+if [ -z "$ASSET_URL" ]; then
+	echo "No matching asset found for $PLATFORM."
+	echo "Download manually from: ${RELEASE_URL:-https://github.com/$REPO/releases/latest}"
+	exit 1
+fi
+
+ARCHIVE="/tmp/miyapad-update.tar.gz"
+echo "Downloading $ASSET_URL"
+curl -fSL "$ASSET_URL" -o "$ARCHIVE"
+
+if [ ! -s "$ARCHIVE" ]; then
+	echo "Downloaded file is empty. Aborting."
+	exit 1
+fi
+
+DIR="$(CDPATH='' cd -- "$(dirname -- "$0")" && pwd -P)"
+echo "Extracting into $DIR"
+tar -xzf "$ARCHIVE" -C "$DIR"
+rm -f "$ARCHIVE"
+
+echo "Update complete. Restart miyapad to apply."

--- a/server/scripts/miyapad-update.sh
+++ b/server/scripts/miyapad-update.sh
@@ -36,7 +36,8 @@ if [ -z "$ASSET_URL" ]; then
 fi
 
 ARCHIVE="$(mktemp "${TMPDIR:-/tmp}/miyapad-update.XXXXXX")"
-trap 'rm -f "$ARCHIVE"' EXIT
+STAGE="$(mktemp -d "${TMPDIR:-/tmp}/miyapad-stage.XXXXXX")"
+trap 'rm -rf "$ARCHIVE" "$STAGE"' EXIT
 echo "Downloading $ASSET_URL"
 curl -fSL "$ASSET_URL" -o "$ARCHIVE"
 
@@ -46,7 +47,12 @@ if [ ! -s "$ARCHIVE" ]; then
 fi
 
 DIR="$(CDPATH='' cd -- "$(dirname -- "$0")" && pwd -P)"
-echo "Extracting into $DIR"
-tar -xzf "$ARCHIVE" -C "$DIR"
+# ponytail: extract to staging first so a bad/interrupted archive can't
+# half-overwrite the live install. Trusted GitHub source, no rollback;
+# add rollback + path-entry validation if updates ever come from mirrors.
+echo "Staging update..."
+tar -xzf "$ARCHIVE" -C "$STAGE"
+echo "Installing into $DIR"
+cp -R "$STAGE"/. "$DIR"/
 
 echo "Update complete. Restart miyapad to apply."

--- a/server/scripts/pack-dist.mjs
+++ b/server/scripts/pack-dist.mjs
@@ -40,6 +40,10 @@ fs.copyFileSync(path.join(root, '..', 'LICENSE'), path.join(distDir, 'LICENSE'))
 
 fs.copyFileSync(path.join(root, 'THIRD_PARTY_LICENSES'), path.join(distDir, 'THIRD_PARTY_LICENSES'));
 
+fs.copyFileSync(path.join(__dirname, 'miyapad-update.sh'), path.join(distDir, 'miyapad-update.sh'));
+fs.chmodSync(path.join(distDir, 'miyapad-update.sh'), 0o755);
+fs.copyFileSync(path.join(__dirname, 'miyapad-update.ps1'), path.join(distDir, 'miyapad-update.ps1'));
+
 fs.writeFileSync(path.join(distDir, 'miyapad.sh'), `#!/bin/sh
 set -e
 DIR="\$(CDPATH='' cd -- "\$(dirname -- "\$0")" && pwd -P)"

--- a/src/components/Modals.tsx
+++ b/src/components/Modals.tsx
@@ -23,6 +23,7 @@ import { AIHordeSettingsModal } from './modals/AIHordeSettingsModal';
 import { CompressionInfoModal } from './modals/CompressionInfoModal';
 import { ConnectionManagerModal } from './modals/ConnectionManagerModal';
 import { SessionsModal } from './modals/SessionsModal';
+import { AboutModal } from './modals/AboutModal';
 import { QuickSwitcher } from './QuickSwitcher';
 import { EditorContextMenu } from './EditorContextMenu';
 import type { ModalsProps } from '../types/components';
@@ -354,6 +355,11 @@ export function Modals({ toggleModal, currentThemeName, setCurrentThemeName, all
 			closeModal=${() => closeModal("sessions")}
 			sessionStorage=${sessionStorage}
 			cancel=${cancel}/>
+
+		<${AboutModal}
+			isOpen=${modalState.about}
+			closeModal=${() => closeModal("about")}
+			isMiyapadEndpoint=${isMiyapadEndpoint}/>
 
 		<${QuickSwitcher}
 			isOpen=${modalState.quickSwitcher}

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -879,6 +879,10 @@ export function Sidebar({ sidebarRef, toggleModal, currentThemeName, setCurrentT
 					<${SVG_MobileSidebar}/>
 				</button>
 			</div>
+			<button
+				onClick=${() => toggleModal("about")}>
+				About
+			</button>
 			${!!lastError && html`
 				<span className="error-text">${lastError}</span>`}
 		</div>

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -880,6 +880,7 @@ export function Sidebar({ sidebarRef, toggleModal, currentThemeName, setCurrentT
 				</button>
 			</div>
 			<button
+				title="About"
 				onClick=${() => toggleModal("about")}>
 				About
 			</button>

--- a/src/components/modals/AboutModal.tsx
+++ b/src/components/modals/AboutModal.tsx
@@ -1,0 +1,54 @@
+import { html } from 'htm/react';
+import { Modal } from '../Modal';
+import { useUpdateCheck } from '../../hooks/useUpdateCheck';
+
+interface AboutModalProps {
+	isOpen: boolean;
+	closeModal: () => void;
+	isMiyapadEndpoint: boolean;
+}
+
+export function AboutModal({ isOpen, closeModal, isMiyapadEndpoint }: AboutModalProps) {
+	const { currentVersion, latestVersion, downloadUrl, repoUrl, updateAvailable, checking, error, check } = useUpdateCheck(isMiyapadEndpoint);
+
+	const updateScript = navigator.userAgent.includes('Windows') ? 'miyapad-update.ps1' : 'miyapad-update.sh';
+
+	return html`
+		<${Modal}
+			isOpen=${isOpen}
+			onClose=${closeModal}
+			title="About miyapad"
+			style=${{ 'max-width': '32em' }}>
+			<div className="vbox" style=${{ gap: '1rem' }}>
+				<div>
+					<strong>Current version:</strong> ${currentVersion}
+				</div>
+				${latestVersion && html`
+					<div style=${{ color: updateAvailable ? 'var(--confirm-color, #4caf50)' : 'inherit', opacity: updateAvailable ? 1 : 0.7 }}>
+						<strong>Latest version:</strong> ${latestVersion} ${updateAvailable ? '(update available)' : '(up to date)'}
+					</div>`}
+				${error && html`<div className="error-text">${error}</div>`}
+
+				<button disabled=${checking} onClick=${check}>
+					${checking ? 'Checking…' : 'Check for Updates'}
+				</button>
+
+				${updateAvailable && html`
+					<div className="vbox" style=${{ gap: '0.5rem' }}>
+						<button onClick=${() => window.open(downloadUrl, '_blank', 'noopener')}>
+							Download v${latestVersion}
+						</button>
+						${isMiyapadEndpoint && html`
+							<div style=${{ fontSize: '0.9em', opacity: 0.85 }}>
+								Or run the update script from your install directory:
+								<code style=${{ display: 'block', marginTop: '4px', fontFamily: 'monospace' }}>./${updateScript}</code>
+							</div>`}
+					</div>`}
+
+				<div style=${{ borderTop: '1px solid rgba(128,128,128,0.2)', paddingTop: '0.8rem', fontSize: '0.9em' }}>
+					<a href=${repoUrl} target="_blank" rel="noopener">View on GitHub</a>
+				</div>
+			</div>
+		</${Modal}>
+	`;
+}

--- a/src/components/modals/AboutModal.tsx
+++ b/src/components/modals/AboutModal.tsx
@@ -18,7 +18,7 @@ export function AboutModal({ isOpen, closeModal, isMiyapadEndpoint }: AboutModal
 			isOpen=${isOpen}
 			onClose=${closeModal}
 			title="About miyapad"
-			style=${{ 'max-width': '32em' }}>
+			style=${{ maxWidth: '32em' }}>
 			<div className="vbox" style=${{ gap: '1rem' }}>
 				<div>
 					<strong>Current version:</strong> ${currentVersion}

--- a/src/hooks/useUpdateCheck.ts
+++ b/src/hooks/useUpdateCheck.ts
@@ -1,0 +1,75 @@
+import { useCallback, useState } from 'react';
+import { APP_VERSION } from '../version';
+
+const GITHUB_API = 'https://api.github.com/repos/lordfoogthe4rd/miyapad/releases/latest';
+const RELEASE_PAGE = 'https://github.com/lordfoogthe4rd/miyapad/releases/latest';
+const REPO_URL = 'https://github.com/lordfoogthe4rd/miyapad';
+
+// ponytail: numeric semver only; non-semver tags parse as NaN.
+// Add proper semver parsing (or the `semver` package) alongside a pre-release checkbox in the future.
+function isNewer(latest: string, current: string): boolean {
+	const a = latest.split('.').map(Number);
+	const b = current.split('.').map(Number);
+	for (let i = 0; i < Math.max(a.length, b.length); i++) {
+		const x = a[i] || 0, y = b[i] || 0;
+		if (x !== y) return x > y;
+	}
+	return false;
+}
+
+interface UpdateState {
+	currentVersion: string;
+	latestVersion: string | null;
+	downloadUrl: string;
+	repoUrl: string;
+	updateAvailable: boolean;
+	checking: boolean;
+	error: string | null;
+	check: () => Promise<void>;
+}
+
+export function useUpdateCheck(isMiyapadEndpoint: boolean): UpdateState {
+	const [latestVersion, setLatestVersion] = useState<string | null>(null);
+	const [downloadUrl, setDownloadUrl] = useState(RELEASE_PAGE);
+	const [checking, setChecking] = useState(false);
+	const [error, setError] = useState<string | null>(null);
+
+	const check = useCallback(async () => {
+		setChecking(true);
+		setError(null);
+		try {
+			let latest: string | null = null;
+			let url = RELEASE_PAGE;
+			if (isMiyapadEndpoint) {
+				const res = await fetch('/version');
+				const data = await res.json();
+				latest = data.latestVersion ?? null;
+				if (data.downloadUrl) url = data.downloadUrl;
+			} else {
+				const res = await fetch(GITHUB_API, { headers: { Accept: 'application/vnd.github+json' } });
+				if (!res.ok) throw new Error(`GitHub API returned ${res.status}`);
+				const data = await res.json();
+				latest = typeof data.tag_name === 'string' ? data.tag_name.replace(/^v/, '') : null;
+				if (data.html_url) url = data.html_url;
+			}
+			if (!latest) throw new Error('Could not determine the latest version.');
+			setLatestVersion(latest);
+			setDownloadUrl(url);
+		} catch (e: unknown) {
+			setError(String(e instanceof Error ? e.message : e));
+		} finally {
+			setChecking(false);
+		}
+	}, [isMiyapadEndpoint]);
+
+	return {
+		currentVersion: APP_VERSION,
+		latestVersion,
+		downloadUrl,
+		repoUrl: REPO_URL,
+		updateAvailable: latestVersion !== null && isNewer(latestVersion, APP_VERSION),
+		checking,
+		error,
+		check
+	};
+}

--- a/src/hooks/useUpdateCheck.ts
+++ b/src/hooks/useUpdateCheck.ts
@@ -1,6 +1,10 @@
 import { useCallback, useState } from 'react';
 import { APP_VERSION } from '../version';
 
+// ponytail: repo slug is duplicated in server/lib/update.ts and the
+// miyapad-update scripts. Kept inline rather than shared config — it spans
+// 3 build contexts (client/server bundles, shell) for a value that never
+// changes. Centralize via build-time injection if it ever does.
 const GITHUB_API = 'https://api.github.com/repos/lordfoogthe4rd/miyapad/releases/latest';
 const RELEASE_PAGE = 'https://github.com/lordfoogthe4rd/miyapad/releases/latest';
 const REPO_URL = 'https://github.com/lordfoogthe4rd/miyapad';

--- a/src/hooks/useUpdateCheck.ts
+++ b/src/hooks/useUpdateCheck.ts
@@ -41,12 +41,13 @@ export function useUpdateCheck(isMiyapadEndpoint: boolean): UpdateState {
 			let latest: string | null = null;
 			let url = RELEASE_PAGE;
 			if (isMiyapadEndpoint) {
-				const res = await fetch('/version');
+				const res = await fetch('/version', { signal: AbortSignal.timeout(10000) });
+				if (!res.ok) throw new Error(`Server returned ${res.status}`);
 				const data = await res.json();
 				latest = data.latestVersion ?? null;
 				if (data.downloadUrl) url = data.downloadUrl;
 			} else {
-				const res = await fetch(GITHUB_API, { headers: { Accept: 'application/vnd.github+json' } });
+				const res = await fetch(GITHUB_API, { headers: { Accept: 'application/vnd.github+json' }, signal: AbortSignal.timeout(10000) });
 				if (!res.ok) throw new Error(`GitHub API returned ${res.status}`);
 				const data = await res.json();
 				latest = typeof data.tag_name === 'string' ? data.tag_name.replace(/^v/, '') : null;


### PR DESCRIPTION
## What

Add an About modal with version display and auto-update infrastructure.

## Why

Users have no way to see what version they're running or whether a newer release exists. The bundled update scripts make server upgrades a one-command operation.

## Changes

- `scripts/write-version.mjs` — reads `package.json`, writes `src/version.ts` with `APP_VERSION` constant; runs automatically on `prebuild` and `prestart`
- `src/version.ts` — generated, gitignored
- `server/lib/update.ts` — `checkForUpdate()` fetches latest GitHub release with 1-hour TTL cache
- `server/routes/system.ts` — `GET /version` now returns `latestVersion` and `downloadUrl` alongside existing fields
- `src/hooks/useUpdateCheck.ts` — shared hook: server mode calls `GET /version`, standalone mode fetches GitHub API directly
- `src/components/modals/AboutModal.tsx` — modal showing current/latest version, "Check for Updates" button, download/script CTAs when an update is available, and GitHub repo link
- `src/components/Modals.tsx` — wires in `AboutModal` under `modalState.about`
- `src/components/Sidebar.tsx` — adds "About" button below the generation controls
- `server/scripts/miyapad-update.sh` — POSIX sh updater for Linux/macOS
- `server/scripts/miyapad-update.ps1` — PowerShell updater for Windows
- `server/scripts/pack-dist.mjs` — copies both update scripts into the dist bundle
- `package.json` — added `version` field (2.5.3) and `prebuild`/`prestart` hooks
- `.gitignore` — ignores `src/version.ts`
- `CHANGELOG.md` — added unreleased entries

## Checklist

- [x] Build passes (`npm run build`)
- [x] Type check passes (`npx tsc --noEmit`)
- [/] Tests pass (`npm test`) — N/A, no test suite exists yet
- [x] Changelog entry added (if user-facing change)
- [x] PR title follows conventional commit format (e.g. `feat:`, `fix:`, `test:`, `chore:`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an About dialog (with current version and repository link) from the sidebar.
  * Added “Check for Updates” with automatic detection, update availability status, and one-click download messaging.
  * Included one-command update scripts in server distributions for Windows, macOS, and Linux.
* **Improvements**
  * Version info is generated automatically during builds and exposed via the backend `/version` response.
  * Update checking is cached for faster, more resilient results.
* **Documentation**
  * Updated endpoint and build/distribution docs to reflect the new About and update capabilities.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->