### PR TITLE
refactor(hooks): collapse the three token counters into one shared effect

### DIFF
--- a/src/hooks/useTokenCounters.ts
+++ b/src/hooks/useTokenCounters.ts
@@ -6,139 +6,108 @@ import { getTokenCount, serverTokenCount } from '../api/index';
 import { API_OPENAI_COMPAT, API_LLAMA_CPP, API_DEEPSEEK } from '../constants';
 import { isAbortError } from '../utils/errors';
 
+/** Everything a counter needs to reach a tokenizer, gathered once by the caller. */
+interface TokenCountConfig {
+	endpoint: string;
+	endpointAPI: number;
+	endpointAPIKey?: string;
+	isMiyapadEndpoint: boolean;
+	useServerTokenization: boolean;
+	sessionStorage: SessionStorageLike;
+	templateReplacements: Record<string, string>;
+	replacePlaceholders: (text: string, replacements: Record<string, string>) => string;
+}
+
+interface SessionStorageLike {
+	sessionEndpoint?: string;
+	proxyEndpoint?: string;
+}
+
+/** `prefix + text + suffix`, or the empty string when there is no text to count. */
+function assemble(prefix: string | undefined, text: string | undefined, suffix: string | undefined): string {
+	return text ? [prefix, text, suffix].join('') : '';
+}
+
+/**
+ * Debounced token count for one assembled block of prompt text, reported
+ * through `apply`. The author note, memory and world info counters differ only
+ * in what they assemble and where the result is stored, so they share this.
+ *
+ * `apply` and `replacePlaceholders` are deliberately absent from the dependency
+ * list: both are rebuilt on every render, and depending on them would restart
+ * the debounce continuously. Neither closes over anything but stable setters.
+ */
+function useDebouncedTokenCount(assembled: string, apply: (tokens: number) => void, config: TokenCountConfig) {
+	const { endpoint, endpointAPI, endpointAPIKey, isMiyapadEndpoint, useServerTokenization, sessionStorage, templateReplacements, replacePlaceholders } = config;
+
+	useEffect(() => {
+		// The OpenAI-compatible and DeepSeek APIs expose no tokenizer to count with.
+		if (assembled === '' || endpointAPI === API_OPENAI_COMPAT || endpointAPI === API_DEEPSEEK) {
+			apply(0);
+			return;
+		}
+
+		const ac = new AbortController();
+		const to = setTimeout(async () => {
+			try {
+				const content = replacePlaceholders(assembled, templateReplacements);
+				const tokenCount = await (useServerTokenization && isMiyapadEndpoint && sessionStorage?.sessionEndpoint
+					? serverTokenCount({ sessionEndpoint: sessionStorage.sessionEndpoint, content, signal: ac.signal })
+					: getTokenCount({
+						endpoint,
+						endpointAPI,
+						...(endpointAPI == API_OPENAI_COMPAT || endpointAPI == API_LLAMA_CPP || endpointAPI == API_DEEPSEEK ? { endpointAPIKey } : {}),
+						content,
+						signal: ac.signal,
+						...(isMiyapadEndpoint ? { proxyEndpoint: sessionStorage.proxyEndpoint } : {})
+					})
+				);
+				apply(tokenCount - 1); // - 1 for BOS, matching llamaCppTokenCount.
+			} catch (e: unknown) {
+				if (!isAbortError(e)) {
+					reportError(e);
+					apply(0);
+				}
+			}
+		}, 500);
+
+		ac.signal.addEventListener('abort', () => clearTimeout(to));
+		return () => ac.abort();
+	}, [assembled, endpoint, endpointAPI, endpointAPIKey, isMiyapadEndpoint, sessionStorage, useServerTokenization, templateReplacements]);
+}
+
 export function useTokenCounters() {
 	const { endpoint, endpointAPI, endpointAPIKey, sessionStorage, isMiyapadEndpoint, useServerTokenization, contextLength, authorNoteTokens, setAuthorNoteTokens, memoryTokens, setMemoryTokens, worldInfo } = useSettings();
 	const { cancel, modalState } = useGeneration();
 	const { templateReplacements, replacePlaceholders } = usePromptBuilder();
 
+	const config: TokenCountConfig = { endpoint, endpointAPI, endpointAPIKey, isMiyapadEndpoint, useServerTokenization, sessionStorage, templateReplacements, replacePlaceholders };
+
 	function handleauthorNoteTokensChange<K extends keyof AuthorNoteData>(key: K, value: AuthorNoteData[K]) {
 		setAuthorNoteTokens((prevauthorNoteTokens: AuthorNoteData) => ({ ...prevauthorNoteTokens, [key]: value }));
 	}
-	// token counts for an
-	useEffect(() => {
-		const order: (keyof AuthorNoteData)[] = ["prefix","text","suffix"]
-		const assembled = authorNoteTokens.text && authorNoteTokens.text !== ""
-			? order.map(key => authorNoteTokens[key]).join("")
-			: "";	
-		if (assembled == "" || endpointAPI == API_OPENAI_COMPAT || endpointAPI == API_DEEPSEEK) {
-			setAuthorNoteTokens((prevauthorNoteTokens: AuthorNoteData) => ({ ...prevauthorNoteTokens, "tokens": 0 }))
-			return
-		}
-		const ac = new AbortController();
-		const to = setTimeout(async () => {
-			try {
-				const content = `${replacePlaceholders(assembled,templateReplacements)}`;
-				const tokenCount = await (useServerTokenization && isMiyapadEndpoint && sessionStorage?.sessionEndpoint
-					? serverTokenCount({ sessionEndpoint: sessionStorage.sessionEndpoint, content, signal: ac.signal })
-					: getTokenCount({
-						endpoint,
-						endpointAPI,
-						...(endpointAPI == API_OPENAI_COMPAT || endpointAPI == API_LLAMA_CPP || endpointAPI == API_DEEPSEEK ? { endpointAPIKey } : {}),
-						content,
-						signal: ac.signal,
-						...(isMiyapadEndpoint ? { proxyEndpoint: sessionStorage.proxyEndpoint } : {})
-					})
-				);
-				setAuthorNoteTokens((prevauthorNoteTokens: AuthorNoteData) => ({
-					...prevauthorNoteTokens,
-					"tokens": tokenCount - 1 
-				}));
-			} catch (e: unknown) {
-				if (!isAbortError(e)){
-					reportError(e);
-					setAuthorNoteTokens((prevauthorNoteTokens: AuthorNoteData) => ({ ...prevauthorNoteTokens, "tokens": 0 }))
-				}
-			}
-		}, 500);
-
-		ac.signal.addEventListener('abort', () => clearTimeout(to));
-		return () => ac.abort();
-	},[authorNoteTokens.text,authorNoteTokens.prefix,authorNoteTokens.suffix,endpoint,endpointAPI,endpointAPIKey,isMiyapadEndpoint,sessionStorage,useServerTokenization,templateReplacements])
 
 	function handleMemoryTokensChange<K extends keyof MemoryTokensData>(key: K, value: MemoryTokensData[K]) {
 		setMemoryTokens((prevMemoryTokens: MemoryTokensData) => ({ ...prevMemoryTokens, [key]: value }));
 	}
-	// token counts for memory
-	useEffect(() => {
-		const order: (keyof MemoryTokensData)[] = ["prefix","text","suffix"]
-		const assembled = memoryTokens.text && memoryTokens.text !== ""
-			? order.map(key => memoryTokens[key]).join("")
-			: "";	
-		if (assembled == "" || endpointAPI == API_OPENAI_COMPAT || endpointAPI == API_DEEPSEEK){
-			setMemoryTokens((prevMemoryTokens: MemoryTokensData) => ({ ...prevMemoryTokens, "tokens": 0 }));
-			return
-		}
 
-		const ac = new AbortController();
-		const to = setTimeout(async () => {
-			try {
-				const content = `${replacePlaceholders(assembled,templateReplacements)}`;
-				const tokenCount = await (useServerTokenization && isMiyapadEndpoint && sessionStorage?.sessionEndpoint
-					? serverTokenCount({ sessionEndpoint: sessionStorage.sessionEndpoint, content, signal: ac.signal })
-					: getTokenCount({
-						endpoint,
-						endpointAPI,
-						...(endpointAPI == API_OPENAI_COMPAT || endpointAPI == API_LLAMA_CPP || endpointAPI == API_DEEPSEEK ? { endpointAPIKey } : {}),
-						content,
-						signal: ac.signal,
-						...(isMiyapadEndpoint ? { proxyEndpoint: sessionStorage.proxyEndpoint } : {})
-					})
-				);
-				setMemoryTokens((prevMemoryTokens: MemoryTokensData) => ({
-					...prevMemoryTokens,
-					"tokens": tokenCount - 1 
-				}));
-			} catch (e: unknown) {
-				if (!isAbortError(e)){
-					reportError(e);
-					setMemoryTokens((prevMemoryTokens: MemoryTokensData) => ({ ...prevMemoryTokens, "tokens": 0 }));
-				}
-			}
-		}, 500);
+	useDebouncedTokenCount(
+		assemble(authorNoteTokens.prefix, authorNoteTokens.text, authorNoteTokens.suffix),
+		tokens => setAuthorNoteTokens((prev: AuthorNoteData) => ({ ...prev, tokens })),
+		config,
+	);
 
-		ac.signal.addEventListener('abort', () => clearTimeout(to));
-		return () => ac.abort();
-	},[memoryTokens.text,memoryTokens.prefix,memoryTokens.suffix,endpoint,endpointAPI,endpointAPIKey,isMiyapadEndpoint,sessionStorage,useServerTokenization,templateReplacements])
-	// token counts for wi
-	useEffect(() => {
-		const assembled = memoryTokens.worldInfo && memoryTokens.worldInfo !== ""
-			? [worldInfo.prefix,memoryTokens.worldInfo,worldInfo.suffix].join("")
-			: "";
-		if (assembled == "" || endpointAPI == API_OPENAI_COMPAT || endpointAPI == API_DEEPSEEK){
-			setMemoryTokens((prevMemoryTokens: MemoryTokensData) => ({ ...prevMemoryTokens, "tokensWI": 0 }));
-			return
-		}
+	useDebouncedTokenCount(
+		assemble(memoryTokens.prefix, memoryTokens.text, memoryTokens.suffix),
+		tokens => setMemoryTokens((prev: MemoryTokensData) => ({ ...prev, tokens })),
+		config,
+	);
 
-		const ac = new AbortController();
-		const to = setTimeout(async () => {
-			try {
-				const content = `${replacePlaceholders(assembled,templateReplacements)}`;
-				const tokenCount = await (useServerTokenization && isMiyapadEndpoint && sessionStorage?.sessionEndpoint
-					? serverTokenCount({ sessionEndpoint: sessionStorage.sessionEndpoint, content, signal: ac.signal })
-					: getTokenCount({
-						endpoint,
-						endpointAPI,
-						...(endpointAPI == API_OPENAI_COMPAT || endpointAPI == API_LLAMA_CPP || endpointAPI == API_DEEPSEEK ? { endpointAPIKey } : {}),
-						content,
-						signal: ac.signal,
-						...(isMiyapadEndpoint ? { proxyEndpoint: sessionStorage.proxyEndpoint } : {})
-					})
-				);
-				setMemoryTokens((prevMemoryTokens: MemoryTokensData) => ({
-					...prevMemoryTokens,
-					"tokensWI": tokenCount - 1 
-				}));
-			} catch (e: unknown) {
-				if (!isAbortError(e)){
-					reportError(e);
-					setMemoryTokens((prevMemoryTokens: MemoryTokensData) => ({ ...prevMemoryTokens, "tokensWI": 0 }));
-				}
-			}
-		}, 500);
-
-		ac.signal.addEventListener('abort', () => clearTimeout(to));
-		return () => ac.abort();
-	},[worldInfo.prefix,memoryTokens.worldInfo,worldInfo.suffix,endpoint,endpointAPI,endpointAPIKey,isMiyapadEndpoint,sessionStorage,useServerTokenization,templateReplacements])
+	useDebouncedTokenCount(
+		assemble(worldInfo.prefix, memoryTokens.worldInfo, worldInfo.suffix),
+		tokensWI => setMemoryTokens((prev: MemoryTokensData) => ({ ...prev, tokensWI })),
+		config,
+	);
 
 	return { handleauthorNoteTokensChange, handleMemoryTokensChange };
 }


### PR DESCRIPTION
## What

Collapses the author note, memory and world info token counters in `useTokenCounters` into one shared debounced effect. Net −31 lines, no behaviour change.

## Why

The three counters were near-identical effect bodies differing only in what they assembled and which key they wrote. The 500 ms debounce, the abort wiring, the server-vs-direct tokenizer choice, the BOS adjustment and the error handling were each written out three times, so any fix to one had to be applied by hand to the other two.

## Changes

- Extracted `useDebouncedTokenCount(assembled, apply, config)`, holding the shared machinery once.
- Extracted `assemble(prefix, text, suffix)` for the `prefix + text + suffix` join and its empty-text guard.
- Each counter is now three lines: what it assembles, and where the result goes.

Two things worth a reviewer's eye:

- **Dependency lists narrowed to the assembled string.** Each effect used to depend on its constituent fields (`memoryTokens.text`, `.prefix`, `.suffix`); it now depends on the joined result, which changes exactly when those do. `apply` and `replacePlaceholders` stay out of the deps — both are rebuilt every render and depending on them would restart the debounce continuously. That was already true of `replacePlaceholders`; it is now stated in a comment rather than left as a silent omission.
- **`contextLength`, `cancel` and `modalState` remain destructured but unused,** as before. Dropping them means dropping the `useGeneration()` call entirely, which changes the hook's context subscriptions — a separate decision from de-duplicating the effects, so it is left out of this diff.

The 18 `useTokenCounters` tests from #35 pass unchanged against this, which is the main evidence the refactor preserves behaviour.

## Checklist

- [x] Build passes (`npm run build`)
- [x] Type check passes (`npx tsc --noEmit`)
- [x] Tests pass (`npm test`) — 330 passing
- [ ] Localization files: applied minimum effort QC if done automatically with AI — n/a, no locale changes
- [x] Written/updated tests for new/changed files — covered by the tests in #35
- [ ] Updated documentation where necessary — n/a
- [ ] Changelog entry added (if user-facing change) — n/a, internal refactor with no user-facing effect
- [x] PR title follows conventional commit format

---

**Stacked on #35.** Based on `tests/cover-untested-functions`, so this diff shows only the refactor commit. Retarget to `master` after #35 merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Standardized token counting across author notes, memory, and world information.
  - Token counts now consistently apply debounced updates, tokenizer selection, placeholder handling, request cancellation, error fallbacks, and beginning-of-sequence adjustments.
  - This improves consistency when token counts are recalculated across supported content fields.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->