### PR TITLE
fix(api): reject a primitive token-count body instead of counting its characters

### DIFF
--- a/src/api/openai.test.ts
+++ b/src/api/openai.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { openaiTabbyTokenCount, openaiModels } from './openai';
+import { openaiAphroditeTokenCount, openaiOobaTokenCount, openaiTabbyTokenCount, openaiModels } from './openai';
 
 const fetchMock = vi.fn();
 
@@ -25,7 +25,7 @@ afterEach(() => {
 	vi.unstubAllGlobals();
 });
 
-describe('openaiTabbyTokenCount', () => {
+describe('openaiTabbyTokenCount request', () => {
 	it('posts the content as `text` to /v1/token/encode and returns the token count', async () => {
 		fetchMock.mockResolvedValue(ok([1, 2, 3, 4]));
 
@@ -73,50 +73,68 @@ describe('openaiTabbyTokenCount', () => {
 
 		expect(lastCall().init.signal).toBe(ac.signal);
 	});
+});
 
-	it('returns -1 on a non-OK response instead of throwing', async () => {
-		fetchMock.mockResolvedValue(notOk(404));
+// All three counters hand their parsed body to the same tokenCountFrom helper,
+// so every case below has to hold for each of them.
+const tokenCounters: [string, (params: TokenCounterParams) => Promise<number>][] = [
+	['openaiAphroditeTokenCount', openaiAphroditeTokenCount],
+	['openaiOobaTokenCount', openaiOobaTokenCount],
+	['openaiTabbyTokenCount', openaiTabbyTokenCount],
+];
 
-		await expect(openaiTabbyTokenCount({ endpoint: 'http://localhost:5000', content: 'x' })).resolves.toBe(-1);
+describe.each(tokenCounters)('%s response handling', (_name, tokenCount) => {
+	const params: TokenCounterParams = { endpoint: 'http://localhost:5000', content: 'x' };
+
+	it('returns the length of an array of token ids', async () => {
+		fetchMock.mockResolvedValue(ok([1, 2, 3, 4]));
+
+		await expect(tokenCount(params)).resolves.toBe(4);
 	});
 
-	it('returns -1 when the request itself rejects', async () => {
-		fetchMock.mockRejectedValue(new TypeError('network down'));
-
-		await expect(openaiTabbyTokenCount({ endpoint: 'http://localhost:5000', content: 'x' })).resolves.toBe(-1);
-	});
-
-	it('returns -1 when an OK response has no usable length (not a Tabby server)', async () => {
-		fetchMock.mockResolvedValue(ok({ detail: 'not found' }));
-
-		await expect(openaiTabbyTokenCount({ endpoint: 'http://localhost:5000', content: 'x' })).resolves.toBe(-1);
-	});
-
-	it('returns -1 when an OK response is a bare value with no length', async () => {
-		fetchMock.mockResolvedValue(ok(null));
-
-		await expect(openaiTabbyTokenCount({ endpoint: 'http://localhost:5000', content: 'x' })).resolves.toBe(-1);
-	});
-
-	it('still accepts an object carrying a numeric length', async () => {
+	it('accepts an object carrying a numeric length', async () => {
 		fetchMock.mockResolvedValue(ok({ length: 12, tokens: [1, 2] }));
 
-		await expect(openaiTabbyTokenCount({ endpoint: 'http://localhost:5000', content: 'x' })).resolves.toBe(12);
+		await expect(tokenCount(params)).resolves.toBe(12);
 	});
 
 	it('accepts a zero-length result', async () => {
 		fetchMock.mockResolvedValue(ok([]));
 
-		await expect(openaiTabbyTokenCount({ endpoint: 'http://localhost:5000', content: '' })).resolves.toBe(0);
+		await expect(tokenCount({ ...params, content: '' })).resolves.toBe(0);
+	});
+
+	it('returns -1 on a non-OK response instead of throwing', async () => {
+		fetchMock.mockResolvedValue(notOk(404));
+
+		await expect(tokenCount(params)).resolves.toBe(-1);
+	});
+
+	it('returns -1 when the request itself rejects', async () => {
+		fetchMock.mockRejectedValue(new TypeError('network down'));
+
+		await expect(tokenCount(params)).resolves.toBe(-1);
+	});
+
+	it('returns -1 when an OK response carries no length', async () => {
+		fetchMock.mockResolvedValue(ok({ detail: 'not found' }));
+
+		await expect(tokenCount(params)).resolves.toBe(-1);
+	});
+
+	it('returns -1 for a null body', async () => {
+		fetchMock.mockResolvedValue(ok(null));
+
+		await expect(tokenCount(params)).resolves.toBe(-1);
 	});
 
 	it('returns -1 for a count that is not a non-negative whole number', async () => {
-		// None of these are usable counts, and getTokenCount screens only for
-		// exactly -1, so each has to become the sentinel here.
+		// getTokenCount screens only for exactly -1, so anything unusable has to
+		// become the sentinel here.
 		for (const length of [-5, -1, 2.5, NaN, Infinity, -Infinity, Number.MAX_SAFE_INTEGER + 1]) {
 			fetchMock.mockResolvedValue(ok({ length }));
 
-			await expect(openaiTabbyTokenCount({ endpoint: 'http://localhost:5000', content: 'x' })).resolves.toBe(-1);
+			await expect(tokenCount(params)).resolves.toBe(-1);
 		}
 	});
 
@@ -124,7 +142,7 @@ describe('openaiTabbyTokenCount', () => {
 		for (const length of ['12', true, null, {}]) {
 			fetchMock.mockResolvedValue(ok({ length }));
 
-			await expect(openaiTabbyTokenCount({ endpoint: 'http://localhost:5000', content: 'x' })).resolves.toBe(-1);
+			await expect(tokenCount(params)).resolves.toBe(-1);
 		}
 	});
 
@@ -134,7 +152,7 @@ describe('openaiTabbyTokenCount', () => {
 		for (const body of ['some error text', '', 42, true]) {
 			fetchMock.mockResolvedValue(ok(body));
 
-			await expect(openaiTabbyTokenCount({ endpoint: 'http://localhost:5000', content: 'x' })).resolves.toBe(-1);
+			await expect(tokenCount(params)).resolves.toBe(-1);
 		}
 	});
 });

--- a/src/api/openai.test.ts
+++ b/src/api/openai.test.ts
@@ -127,6 +127,16 @@ describe('openaiTabbyTokenCount', () => {
 			await expect(openaiTabbyTokenCount({ endpoint: 'http://localhost:5000', content: 'x' })).resolves.toBe(-1);
 		}
 	});
+
+	it('returns -1 for a primitive body rather than reading its character count', async () => {
+		// A bare JSON string has a `.length`, and it is a perfectly plausible
+		// non-negative integer — it is just not a token count.
+		for (const body of ['some error text', '', 42, true]) {
+			fetchMock.mockResolvedValue(ok(body));
+
+			await expect(openaiTabbyTokenCount({ endpoint: 'http://localhost:5000', content: 'x' })).resolves.toBe(-1);
+		}
+	});
 });
 
 describe('openaiModels', () => {

--- a/src/api/openai.ts
+++ b/src/api/openai.ts
@@ -1,13 +1,22 @@
 import { parseEventStream, applyTemperatureToProbs } from './common';
 
 /**
- * A token count is only usable if it is a non-negative whole number. A
- * fractional or negative value, NaN or Infinity becomes the -1 "not this
- * backend" sentinel, so getTokenCount falls through to the next counter rather
- * than passing the value on as a real count — it only screens for exactly -1.
+ * The token count carried by a parsed token-count response, or the -1 "not this
+ * backend" sentinel when the body cannot supply one.
+ *
+ * Every shape in use here exposes the count as `length`: an array of token ids
+ * (Aphrodite) or an object with an explicit `length` (Tabby, Ooba). A primitive
+ * body is rejected outright, because a bare JSON string would otherwise hand
+ * back its character count — a plausible-looking number that is not a count at
+ * all. The count itself must be a non-negative whole number, since
+ * getTokenCount screens only for exactly -1 and passes anything else on as
+ * real.
  */
-function usableTokenCount(value: unknown): number {
-	return typeof value === 'number' && Number.isSafeInteger(value) && value >= 0 ? value : -1;
+function tokenCountFrom(body: unknown): number {
+	if (typeof body !== 'object' || body === null)
+		return -1;
+	const { length } = body as { length?: unknown };
+	return typeof length === 'number' && Number.isSafeInteger(length) && length >= 0 ? length : -1;
 }
 
 interface OpenaiStreamChunk {
@@ -47,8 +56,7 @@ export async function openaiAphroditeTokenCount({ endpoint, endpointAPIKey, prox
 		});
 		if (!res.ok)
 			throw new Error(`HTTP ${res.status}`);
-		const tokens = await res.json();
-		return usableTokenCount(tokens?.length);
+		return tokenCountFrom(await res.json());
 	} catch (e) {
 		return -1;
 	}
@@ -69,8 +77,7 @@ export async function openaiOobaTokenCount({ endpoint, proxyEndpoint, signal, ..
 		});
 		if (!res.ok)
 			throw new Error(`HTTP ${res.status}`);
-		const { length } = await res.json();
-		return usableTokenCount(length);
+		return tokenCountFrom(await res.json());
 	} catch (e) {
 		return -1;
 	}
@@ -92,8 +99,7 @@ export async function openaiTabbyTokenCount({ endpoint, endpointAPIKey, proxyEnd
 		});
 		if (!res.ok)
 			throw new Error(`HTTP ${res.status}`);
-		const tokens = await res.json();
-		return usableTokenCount(tokens?.length);
+		return tokenCountFrom(await res.json());
 	} catch (e) {
 		return -1;
 	}


### PR DESCRIPTION
## What

Closes the last hole in the OpenAI-compatible token-count fallback chain: a server answering `200` with a bare JSON string had its character count accepted as a token count.

## Why

#35 validated the extracted `length` with `Number.isSafeInteger(value) && value >= 0`, which correctly rejects `NaN`, `Infinity`, and negative or fractional values. It cannot reject a string's `.length`, though — `"some error text".length` is `15`, a perfectly ordinary non-negative safe integer. `getTokenCount` screens only for exactly `-1`, so that number stood in as a real count, stopping the Aphrodite → Ooba → Tabby fallback and reporting a token count derived from the length of an error message.

The same applied to `openaiOobaTokenCount`, which destructured `const { length } = await res.json()` — destructuring a string yields its length just as readily.

## Changes

- `usableTokenCount(value)` becomes `tokenCountFrom(body)`, taking the parsed body rather than a pre-extracted value. It requires a non-null object before reading `length`, which admits both shapes in use — an array of token ids (Aphrodite) and an object with an explicit `length` (Tabby, Ooba) — while rejecting every primitive.
- All three counters now read `return tokenCountFrom(await res.json());`.
- Tests for a string, an empty string, a number and a boolean body.

No changelog entry: the entry added in #35 ("Token counts no longer come out blank against an OpenAI-compatible server that answers the token-counting request in an unexpected format") already describes this from the user's side.

## Checklist

- [x] Build passes (`npm run build`)
- [x] Type check passes (`npx tsc --noEmit`)
- [x] Tests pass (`npm test`) — 334 passing
- [ ] Localization files: applied minimum effort QC if done automatically with AI — n/a, no locale changes
- [x] Written/updated tests for new/changed files
- [ ] Updated documentation where necessary — n/a
- [ ] Changelog entry added (if user-facing change) — covered by the entry in #35
- [x] PR title follows conventional commit format

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved token-count handling for Aphrodite, Ooba, and Tabby responses.
  - Primitive response values such as strings, numbers, booleans, and empty responses are no longer incorrectly interpreted as token counts.
  - Invalid, missing, negative, or non-integer length values are now rejected consistently, improving token usage reporting.
  - Token-count handling is now more reliable when requests fail or services return unsuccessful responses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->